### PR TITLE
Use buckets to determine whether a part of boolean/and/or expression matches

### DIFF
--- a/src/expressions/operators/boolean/OrOperator.js
+++ b/src/expressions/operators/boolean/OrOperator.js
@@ -3,6 +3,8 @@ import Specificity from '../../Specificity';
 import Sequence from '../../dataTypes/Sequence';
 import { trueBoolean, falseBoolean } from '../../dataTypes/createAtomicValue';
 import { DONE_TOKEN, notReady, ready } from '../../util/iterators';
+import isSubtypeOf from '../../dataTypes/isSubtypeOf';
+import getBucketsForNode from '../../../getBucketsForNode';
 
 /**
  * @extends {Expression}
@@ -49,12 +51,30 @@ class OrOperator extends Expression {
 		let i = 0;
 		let resultSequence = null;
 		let done = false;
+
+		let contextItemBuckets = null;
+		if (dynamicContext !== null) {
+			const contextItem = dynamicContext.contextItem;
+			if (contextItem !== null && isSubtypeOf(contextItem.type, 'node()')) {
+				contextItemBuckets = getBucketsForNode(contextItem.value);
+			}
+		}
+
 		return new Sequence({
 			next: () => {
 				if (!done) {
 					while (i < this._subExpressions.length) {
 						if (!resultSequence) {
-							resultSequence = this._subExpressions[i].evaluateMaybeStatically(dynamicContext, executionParameters);
+							const subExpression = this._subExpressions[i];
+							if (contextItemBuckets !== null && subExpression.getBucket() !== null) {
+								if (!contextItemBuckets.includes(subExpression.getBucket())) {
+									// This subExpression may NEVER match the given node
+									// We do not even have to evaluate the expression
+									i++;
+									continue;
+								}
+							}
+							resultSequence = subExpression.evaluateMaybeStatically(dynamicContext, executionParameters);
 						}
 						const ebv = resultSequence.tryGetEffectiveBooleanValue();
 						if (!ebv.ready) {

--- a/test/specs/parsing/operators/boolean/AndOperator.tests.js
+++ b/test/specs/parsing/operators/boolean/AndOperator.tests.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import {
 	evaluateXPathToBoolean
 } from 'fontoxpath';
+import * as slimdom from 'slimdom';
 
 import evaluateXPathToAsyncSingleton from 'test-helpers/evaluateXPathToAsyncSingleton';
 
@@ -10,6 +11,10 @@ describe('and operator', () => {
 
 	it('can parse an "and" selector', () => {
 		chai.assert.isTrue(evaluateXPathToBoolean('true() and true()'));
+	});
+
+	it('can optimize an and expression with buckets', () => {
+		chai.assert.isFalse(evaluateXPathToBoolean('self::p and false()', new slimdom.Document()));
 	});
 
 	it('can parse a concatenation of ands',


### PR DESCRIPTION
This may save some performance when using a lot of selectors looking
like `self::p or self::div`.