### PR TITLE
Remove all outward usage of ExternalDomFacade

### DIFF
--- a/src/domFacade/DomFacade.ts
+++ b/src/domFacade/DomFacade.ts
@@ -7,7 +7,6 @@ import {
 	ConcreteParentNode,
 	NODE_TYPES
 } from './ConcreteNode';
-import ExternalDomFacade from './ExternalDomFacade';
 import IDomFacade from './IDomFacade';
 import IWrappingDomFacade from './IWrappingDomFacade';
 
@@ -17,7 +16,7 @@ import IWrappingDomFacade from './IWrappingDomFacade';
 class DomFacade implements IWrappingDomFacade {
 	public orderOfDetachedNodes: ConcreteNode[];
 
-	constructor(private readonly _domFacade: ExternalDomFacade) {
+	constructor(private readonly _domFacade: IDomFacade) {
 		/**
 		 * Defines the ordering of detached nodes, to ensure stable sorting of unrelated nodes.
 		 */
@@ -59,24 +58,23 @@ class DomFacade implements IWrappingDomFacade {
 	}
 
 	public getFirstChild(node: ConcreteParentNode): ConcreteChildNode {
-		return this._domFacade['getFirstChild'](node);
+		return this._domFacade['getFirstChild'](node) as ConcreteChildNode;
 	}
 
 	public getLastChild(node: ConcreteParentNode): ConcreteChildNode {
-		return this._domFacade['getLastChild'](node);
+		return this._domFacade['getLastChild'](node) as ConcreteChildNode;
 	}
 
 	public getNextSibling(node: ConcreteChildNode): ConcreteChildNode {
-		return this._domFacade['getNextSibling'](node);
+		return this._domFacade['getNextSibling'](node) as ConcreteChildNode;
 	}
 
-	public getParentNode(node: ConcreteElementNode): ConcreteParentNode;
-	public getParentNode(node: ConcreteNode): ConcreteParentNode {
-		return this._domFacade['getParentNode'](node);
+	public getParentNode(node: ConcreteChildNode): ConcreteParentNode {
+		return this._domFacade['getParentNode'](node) as ConcreteParentNode;
 	}
 
 	public getPreviousSibling(node: ConcreteChildNode): ConcreteChildNode {
-		return this._domFacade['getPreviousSibling'](node);
+		return this._domFacade['getPreviousSibling'](node) as ConcreteChildNode;
 	}
 
 	// Can be used to create an extra frame when tracking dependencies

--- a/src/domFacade/ExternalDomFacade.ts
+++ b/src/domFacade/ExternalDomFacade.ts
@@ -1,50 +1,41 @@
-import {
-	ConcreteAttributeNode,
-	ConcreteCharacterDataNode,
-	ConcreteChildNode,
-	ConcreteElementNode,
-	ConcreteNode,
-	ConcreteParentNode,
-	NODE_TYPES
-} from './ConcreteNode';
-
+import { NODE_TYPES } from './ConcreteNode';
 import IDomFacade from './IDomFacade';
 
 export default class ExternalDomFacade implements IDomFacade {
-	public ['getAllAttributes'](node: ConcreteElementNode): ConcreteAttributeNode[] {
+	public ['getAllAttributes'](node: Node): Attr[] {
 		if (node.nodeType !== NODE_TYPES.ELEMENT_NODE) {
 			return [];
 		}
 		return Array.from(node['attributes']);
 	}
-	public ['getAttribute'](node: ConcreteNode, attributeName: string): string {
+	public ['getAttribute'](node: Node, attributeName: string): string {
 		if (node.nodeType !== NODE_TYPES.ELEMENT_NODE) {
 			return null;
 		}
 		return node['getAttribute'](attributeName);
 	}
-	public ['getChildNodes'](node: ConcreteParentNode): ConcreteChildNode[] {
-		return Array.from(node['childNodes']) as ConcreteChildNode[];
+	public ['getChildNodes'](node: Node): Node[] {
+		return Array.from(node['childNodes']) as Node[];
 	}
-	public ['getData'](node: ConcreteAttributeNode | ConcreteCharacterDataNode): string {
+	public ['getData'](node: Attr | CharacterData): string {
 		return node['data'];
 	}
-	public ['getFirstChild'](node: ConcreteParentNode): ConcreteChildNode {
-		return node['firstChild'] as ConcreteChildNode;
+	public ['getFirstChild'](node: Node): Node {
+		return node['firstChild'] as Node;
 	}
-	public ['getLastChild'](node: ConcreteParentNode): ConcreteChildNode {
-		return node['lastChild'] as ConcreteChildNode;
+	public ['getLastChild'](node: Node): Node {
+		return node['lastChild'] as Node;
 	}
-	public ['getNextSibling'](node: ConcreteChildNode): ConcreteChildNode {
-		return node['nextSibling'] as ConcreteChildNode;
+	public ['getNextSibling'](node: Node): Node {
+		return node['nextSibling'];
 	}
-	public ['getParentNode'](node: ConcreteNode): ConcreteParentNode {
+	public ['getParentNode'](node: Node): Node {
 		if (node['nodeType'] === NODE_TYPES.ATTRIBUTE_NODE) {
 			return node['ownerElement'];
 		}
-		return node['parentNode'] as ConcreteParentNode;
+		return node['parentNode'] as Node;
 	}
-	public ['getPreviousSibling'](node: ConcreteChildNode): ConcreteChildNode {
-		return node['previousSibling'] as ConcreteChildNode;
+	public ['getPreviousSibling'](node: Node): Node {
+		return node['previousSibling'];
 	}
 }

--- a/src/domFacade/IDomFacade.ts
+++ b/src/domFacade/IDomFacade.ts
@@ -1,20 +1,11 @@
-import {
-	ConcreteAttributeNode,
-	ConcreteCharacterDataNode,
-	ConcreteChildNode,
-	ConcreteElementNode,
-	ConcreteNode,
-	ConcreteParentNode
-} from './ConcreteNode';
-
 export default interface IDomFacade {
-	getAllAttributes(node: ConcreteElementNode): ConcreteAttributeNode[];
-	getAttribute(node: ConcreteElementNode, attributeName: string): string;
-	getChildNodes(node: ConcreteParentNode): ConcreteChildNode[];
-	getData(node: ConcreteAttributeNode | ConcreteCharacterDataNode): string;
-	getFirstChild(node: ConcreteParentNode): ConcreteChildNode;
-	getLastChild(node: ConcreteParentNode): ConcreteChildNode;
-	getNextSibling(node: ConcreteChildNode): ConcreteChildNode;
-	getParentNode(node: ConcreteNode): ConcreteParentNode;
-	getPreviousSibling(node: ConcreteChildNode): ConcreteChildNode;
+	getAllAttributes(node: Element): Attr[];
+	getAttribute(node: Element, attributeName: string): string | null;
+	getChildNodes(node: Node): Node[];
+	getData(node: Attr | CharacterData): string;
+	getFirstChild(node: Node): Node | null;
+	getLastChild(node: Node): Node | null;
+	getNextSibling(node: Node): Node | null;
+	getParentNode(node: Node): Node | null;
+	getPreviousSibling(node: Node): Node | null;
 }

--- a/src/domFacade/IWrappingDomFacade.ts
+++ b/src/domFacade/IWrappingDomFacade.ts
@@ -1,8 +1,25 @@
-import { ConcreteNode } from './ConcreteNode';
-import ExternalDomFacade from './ExternalDomFacade';
+import {
+	ConcreteAttributeNode,
+	ConcreteCharacterDataNode,
+	ConcreteChildNode,
+	ConcreteElementNode,
+	ConcreteNode,
+	ConcreteParentNode
+} from './ConcreteNode';
 import IDomFacade from './IDomFacade';
 
 export default interface IWrappingDomFacade extends IDomFacade {
 	orderOfDetachedNodes: ConcreteNode[];
-	unwrap(): ExternalDomFacade;
+
+	getAllAttributes(node: ConcreteElementNode): ConcreteAttributeNode[];
+	getAttribute(node: ConcreteElementNode, attributeName: string): string;
+	getChildNodes(node: ConcreteParentNode): ConcreteChildNode[];
+	getData(node: ConcreteAttributeNode | ConcreteCharacterDataNode): string;
+	getFirstChild(node: ConcreteParentNode): ConcreteChildNode;
+	getLastChild(node: ConcreteParentNode): ConcreteChildNode;
+	getNextSibling(node: Node): ConcreteChildNode;
+	getParentNode(node: ConcreteChildNode | ConcreteAttributeNode): ConcreteParentNode;
+	getPreviousSibling(node: ConcreteChildNode): ConcreteChildNode;
+
+	unwrap(): IDomFacade;
 }

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -11,6 +11,7 @@ import Expression from './expressions/Expression';
 import { DONE_TOKEN, notReady, ready } from './expressions/util/iterators';
 import getBucketsForNode from './getBucketsForNode';
 import INodesFactory from './nodesFactory/INodesFactory';
+import IDomFacade from './domFacade/IDomFacade';
 
 function transformMapToObject(map, dynamicContext) {
 	const mapObj = {};
@@ -154,7 +155,7 @@ export type Options = {
 function evaluateXPath(
 	selector: string,
 	contextItem?: any | null,
-	domFacade?: ExternalDomFacade | null,
+	domFacade?: IDomFacade | null,
 	variables?: { [s: string]: any } | null,
 	returnType?: ReturnType | null,
 	options?: Options | null

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -3,7 +3,7 @@ import IDocumentWriter from '../documentWriter/IDocumentWriter';
 import wrapExternalDocumentWriter from '../documentWriter/wrapExternalDocumentWriter';
 import domBackedDomFacade from '../domFacade/domBackedDomFacade';
 import DomFacade from '../domFacade/DomFacade';
-import ExternalDomFacade from '../domFacade/ExternalDomFacade';
+import IDomFacade from '../domFacade/IDomFacade';
 import IWrappingDomFacade from '../domFacade/IWrappingDomFacade';
 import { UpdatingOptions } from '../evaluateUpdatingExpression';
 import { Options } from '../evaluateXPath';
@@ -47,7 +47,7 @@ function normalizeEndOfLines(xpathString: string) {
 export default function buildEvaluationContext(
 	expressionString: string,
 	contextItem: any,
-	domFacade: ExternalDomFacade | null,
+	domFacade: IDomFacade | null,
 	variables: object,
 	externalOptions: Options | UpdatingOptions,
 	compilationOptions: {

--- a/src/expressions/dataTypes/documentOrderUtils.ts
+++ b/src/expressions/dataTypes/documentOrderUtils.ts
@@ -1,4 +1,9 @@
-import { ConcreteNode } from '../../domFacade/ConcreteNode';
+import {
+	ConcreteNode,
+	NODE_TYPES,
+	ConcreteChildNode,
+	ConcreteAttributeNode
+} from '../../domFacade/ConcreteNode';
 import IDomFacade from '../../domFacade/IDomFacade';
 import IWrappingDomFacade from '../../domFacade/IWrappingDomFacade';
 import isSubtypeOf from './isSubtypeOf';
@@ -43,12 +48,15 @@ function compareSiblingElements(
  * @param	node       The node to find all ancestors of
  * @return	All of the ancestors of the given node
  */
-function findAllAncestors(domFacade: IDomFacade, node: ConcreteNode): ConcreteNode[] {
+function findAllAncestors(domFacade: IWrappingDomFacade, node: ConcreteNode): ConcreteNode[] {
 	const ancestors: ConcreteNode[] = [];
 	for (
-		let ancestor: ConcreteNode = node;
+		let ancestor = node;
 		ancestor;
-		ancestor = domFacade.getParentNode(ancestor)
+		ancestor =
+			node.nodeType === NODE_TYPES.DOCUMENT_NODE
+				? null
+				: domFacade.getParentNode(ancestor as ConcreteChildNode | ConcreteAttributeNode)
 	) {
 		ancestors.unshift(ancestor);
 	}
@@ -69,7 +77,7 @@ function findAllAncestors(domFacade: IDomFacade, node: ConcreteNode): ConcreteNo
  */
 function compareElements(
 	tieBreakerArr: ConcreteNode[],
-	domFacade: IDomFacade,
+	domFacade: IWrappingDomFacade,
 	nodeA: ConcreteNode,
 	nodeB: ConcreteNode
 ): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import parseExpression from './parsing/parseExpression';
 import precompileXPath from './precompileXPath';
 import registerCustomXPathFunction from './registerCustomXPathFunction';
 import registerXQueryModule from './registerXQueryModule';
+import IDomFacade from './domFacade/IDomFacade';
 
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath');
@@ -71,7 +72,7 @@ function compareSpecificity(xpathStringA, xpathStringB): -1 | 0 | 1 {
 	return parseXPath(xpathStringA).specificity.compareTo(parseXPath(xpathStringB).specificity);
 }
 
-const domFacade = new ExternalDomFacade();
+const domFacade: IDomFacade = new ExternalDomFacade();
 
 /* istanbul ignore next */
 if (typeof window !== 'undefined') {
@@ -98,6 +99,7 @@ if (typeof window !== 'undefined') {
 }
 
 export {
+	IDomFacade,
 	domFacade,
 	evaluateXPath,
 	evaluateXPathToArray,

--- a/src/registerCustomXPathFunction.ts
+++ b/src/registerCustomXPathFunction.ts
@@ -2,7 +2,7 @@ import adaptJavaScriptValueToXPathValue from './expressions/adaptJavaScriptValue
 import isSubtypeOf from './expressions/dataTypes/isSubtypeOf';
 import { registerFunction } from './expressions/functions/functionRegistry';
 
-import ExternalDomFacade from './domFacade/ExternalDomFacade';
+import IDomFacade from './domFacade/IDomFacade';
 import DynamicContext from './expressions/DynamicContext';
 import ExecutionParameters from './expressions/ExecutionParameters';
 import {
@@ -55,13 +55,13 @@ function splitFunctionName(
 
 	// Register this prefix to a random namespace uri
 	return {
-		namespaceURI: namespaceURIForPrefix,
-		localName
+		localName,
+		namespaceURI: namespaceURIForPrefix
 	};
 }
 
 type DomFacadeWrapper = {
-	domFacade: ExternalDomFacade;
+	domFacade: IDomFacade;
 };
 
 /**


### PR DESCRIPTION
IDomFacade is the outward facing interface, which works with the Node type and its subclasses. ExternalDomFacade is the default wrapper which only translates method calls to property gets. IWrappingDomFacade is the internal domFacade, which uses the ConcreteNode type unions and has additional methods/properties.