### PR TITLE
Add a minimal node type for better typescript integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ registerCustomXPathFunction(name, signature, returnType, callback);
 
 ### Typescript
 
-We support [TypeScript](https://github.com/Microsoft/TypeScript); e.g. expose a minimal Node type. You can use generic types to get your type, without casting.
+We support [TypeScript](https://github.com/Microsoft/TypeScript); and expose a minimal Node type.
+You can use generic types to get the type of the DOM implementation you are using without having to
+cast it.
 
 ```ts
 const myNodes = evaluateXPathToNodes<slimdom.Node>(

--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ registerCustomXPathFunction(name, signature, returnType, callback);
 * `returnType` `string` The return type of the function.
 * `callback` `function` The function itself.
 
+### Typescript
+
+We support [TypeScript](https://github.com/Microsoft/TypeScript); e.g. expose a minimal Node type. You can use generic types to get your type, without casting.
+
+```ts
+const myNodes = evaluateXPathToNodes<slimdom.Node>(
+  '<foo>bar</foo>',
+  null,
+  null,
+  null,
+  {language: evaluateXPath.XQUERY_3_1_LANGUAGE}
+);
+
+// Type of myNodes is: slimdom.Node[] .
+```
+
 ## Features
 
 Note that this engine assumes [XPath 1.0 compatibility

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -156,7 +156,7 @@ async function rerunXPath() {
 		astJsonMl.innerText = stringifyJsonMl(ast, 0, 0);
 
 		const document = new Document();
-		document.appendChild(parseAst(document, ast));
+		document.appendChild(parseAst(document, ast) as Node);
 		document.documentElement.setAttributeNS(
 			'http://www.w3.org/2001/XMLSchema-instance',
 			'xsi:schemaLocation',

--- a/demo/parseAst.ts
+++ b/demo/parseAst.ts
@@ -1,4 +1,15 @@
 import { IAST } from '../src/parsing/astHelper';
+import { Element, Node, Text } from '../src/types/Types';
+
+type DemoDocument = {
+	createElementNS: (namespaceURI: string, prefix: string) => DemoElement,
+	createTextNode: (data: string) => Text
+};
+
+type DemoElement = Element & {
+	appendChild: any,
+	setAttributeNS: any
+};
 
 /**
  * Transform the given JsonML fragment into the corresponding DOM structure, using the given document to
@@ -12,7 +23,7 @@ import { IAST } from '../src/parsing/astHelper';
  *
  * @return            The root node of the constructed DOM fragment
  */
-export function parseAst(document: Document, ast: IAST, parent?: Element): Node {
+export function parseAst(document: DemoDocument, ast: IAST, parent?: DemoElement): Node {
 	if (typeof ast === 'string' || typeof ast === 'number') {
 		return document.createTextNode(ast as string);
 	}

--- a/demo/parseAst.ts
+++ b/demo/parseAst.ts
@@ -1,4 +1,9 @@
 import { IAST } from '../src/parsing/astHelper';
+// import {
+// 	Document,
+// 	Element,
+// 	Node
+// } from '../src/types/Types';
 
 /**
  * Transform the given JsonML fragment into the corresponding DOM structure, using the given document to

--- a/demo/parseAst.ts
+++ b/demo/parseAst.ts
@@ -1,9 +1,4 @@
 import { IAST } from '../src/parsing/astHelper';
-// import {
-// 	Document,
-// 	Element,
-// 	Node
-// } from '../src/types/Types';
 
 /**
  * Transform the given JsonML fragment into the corresponding DOM structure, using the given document to

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
+		"lib": ["dom"],
 		"outDir": "./built",
 		"baseUrl": "..",
 		"target": "es2017",

--- a/src/documentWriter/IDocumentWriter.ts
+++ b/src/documentWriter/IDocumentWriter.ts
@@ -1,9 +1,8 @@
+import { Document, Element, Node } from '../types/Types';
+
 /**
  * @public
  */
-
-import { Document, Element, Node } from '../types/Types';
-
 export default interface IDocumentWriter {
 	insertBefore(parent: Element | Document, newNode: Node, referenceNode: Node | null): void;
 	removeAttributeNS(node: Element, namespace: string, name: string): void;

--- a/src/documentWriter/IDocumentWriter.ts
+++ b/src/documentWriter/IDocumentWriter.ts
@@ -1,6 +1,9 @@
 /**
  * @public
  */
+
+import { Document, Element, Node } from '../types/Types';
+
 export default interface IDocumentWriter {
 	insertBefore(parent: Element | Document, newNode: Node, referenceNode: Node | null): void;
 	removeAttributeNS(node: Element, namespace: string, name: string): void;

--- a/src/domFacade/ConcreteNode.ts
+++ b/src/domFacade/ConcreteNode.ts
@@ -1,3 +1,13 @@
+import {
+	Attr,
+	CDATASection,
+	Comment,
+	Document,
+	Element,
+	ProcessingInstruction,
+	Text
+} from '../types/Types';
+
 export const enum NODE_TYPES {
 	ELEMENT_NODE = 1,
 	ATTRIBUTE_NODE = 2,

--- a/src/domFacade/ExternalDomFacade.ts
+++ b/src/domFacade/ExternalDomFacade.ts
@@ -1,3 +1,4 @@
+import { Attr, CharacterData, Node } from '../types/Types';
 import { NODE_TYPES } from './ConcreteNode';
 import IDomFacade from './IDomFacade';
 
@@ -15,7 +16,7 @@ export default class ExternalDomFacade implements IDomFacade {
 		return node['getAttribute'](attributeName);
 	}
 	public ['getChildNodes'](node: Node): Node[] {
-		return Array.from(node['childNodes']) as Node[];
+		return Array.from(node['childNodes']);
 	}
 	public ['getData'](node: Attr | CharacterData): string {
 		return node['data'];

--- a/src/domFacade/IDomFacade.ts
+++ b/src/domFacade/IDomFacade.ts
@@ -1,8 +1,13 @@
+<<<<<<< HEAD
 /**
  * The base interface of a dom facade
  *
  * @public
  */
+=======
+import { Attr, CharacterData, Element, Node } from '../types/Types';
+
+>>>>>>> Add a minimal node type for better typescript integration
 export default interface IDomFacade {
 	getAllAttributes(node: Element): Attr[];
 	getAttribute(node: Element, attributeName: string): string | null;

--- a/src/domFacade/IDomFacade.ts
+++ b/src/domFacade/IDomFacade.ts
@@ -1,10 +1,10 @@
+import { Attr, CharacterData, Element, Node } from '../types/Types';
+
 /**
  * The base interface of a dom facade
  *
  * @public
  */
-import { Attr, CharacterData, Element, Node } from '../types/Types';
-
 export default interface IDomFacade {
 	getAllAttributes(node: Element): Attr[];
 	getAttribute(node: Element, attributeName: string): string | null;

--- a/src/domFacade/IDomFacade.ts
+++ b/src/domFacade/IDomFacade.ts
@@ -1,13 +1,10 @@
-<<<<<<< HEAD
 /**
  * The base interface of a dom facade
  *
  * @public
  */
-=======
 import { Attr, CharacterData, Element, Node } from '../types/Types';
 
->>>>>>> Add a minimal node type for better typescript integration
 export default interface IDomFacade {
 	getAllAttributes(node: Element): Attr[];
 	getAttribute(node: Element, attributeName: string): string | null;

--- a/src/domFacade/IWrappingDomFacade.ts
+++ b/src/domFacade/IWrappingDomFacade.ts
@@ -1,3 +1,4 @@
+import { Node } from '../types/Types';
 import {
 	ConcreteAttributeNode,
 	ConcreteCharacterDataNode,

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -171,7 +171,6 @@ interface IReturnTypes {
 	[ReturnType.ASYNC_ITERATOR]: AsyncIterator<any>;
 }
 
-
 /**
  * Evaluates an XPath on the given contextItem.
  *
@@ -193,7 +192,10 @@ interface IReturnTypes {
  *
  * @returns The result of executing this XPath
  */
-const evaluateXPath = function _evaluateXPath<T extends Node, TReturnType extends keyof IReturnTypes>(
+const evaluateXPath = function _evaluateXPath<
+	T extends Node,
+	TReturnType extends keyof IReturnTypes
+>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
@@ -201,7 +203,7 @@ const evaluateXPath = function _evaluateXPath<T extends Node, TReturnType extend
 	returnType?: TReturnType,
 	options?: Options | null
 ): IReturnTypes[TReturnType] {
-	returnType = returnType || ReturnType.ANY as any;
+	returnType = returnType || (ReturnType.ANY as any);
 	if (!selector || typeof selector !== 'string') {
 		throw new TypeError("Failed to execute '_': xpathExpression must be a string.");
 	}
@@ -309,9 +311,9 @@ const evaluateXPath = function _evaluateXPath<T extends Node, TReturnType extend
 				if (!isSubtypeOf(first.value.type, 'node()')) {
 					throw new Error(
 						'Expected XPath ' +
-						selector +
-						' to resolve to Node. Got ' +
-						first.value.type
+							selector +
+							' to resolve to Node. Got ' +
+							first.value.type
 					);
 				}
 				return first.value.value;
@@ -474,8 +476,8 @@ const evaluateXPath = function _evaluateXPath<T extends Node, TReturnType extend
 						if (!transformedArray.ready) {
 							throw new Error(
 								'Expected XPath ' +
-								selector +
-								' to synchronously resolve to an array'
+									selector +
+									' to synchronously resolve to an array'
 							);
 						}
 						return transformedArray.value;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -195,10 +195,7 @@ export interface IReturnTypes {
  *
  * @returns The result of executing this XPath
  */
-const evaluateXPath = function _evaluateXPath<
-	T extends Node,
-	TReturnType extends keyof IReturnTypes
->(
+function evaluateXPath<TReturnType extends keyof IReturnTypes> (
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
@@ -208,7 +205,7 @@ const evaluateXPath = function _evaluateXPath<
 ): IReturnTypes[TReturnType] {
 	returnType = returnType || (ReturnType.ANY as any);
 	if (!selector || typeof selector !== 'string') {
-		throw new TypeError("Failed to execute '_': xpathExpression must be a string.");
+		throw new TypeError("Failed to execute 'evaluateXPath': xpathExpression must be a string.");
 	}
 
 	options = options || {};

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -160,13 +160,13 @@ export enum ReturnType {
 /**
  * @public
  */
-export interface IReturnTypes {
+export interface IReturnTypes<T extends Node> {
 	[ReturnType.ANY]: any;
 	[ReturnType.NUMBER]: number;
 	[ReturnType.STRING]: string;
 	[ReturnType.BOOLEAN]: boolean;
-	[ReturnType.NODES]: Node[];
-	[ReturnType.FIRST_NODE]: Node;
+	[ReturnType.NODES]: T[];
+	[ReturnType.FIRST_NODE]: T|null;
 	[ReturnType.STRINGS]: string[];
 	[ReturnType.MAP]: { [s: string]: any };
 	[ReturnType.ARRAY]: any[];
@@ -195,14 +195,14 @@ export interface IReturnTypes {
  *
  * @returns The result of executing this XPath
  */
-function evaluateXPath<TReturnType extends keyof IReturnTypes> (
+function evaluateXPath<TNode extends Node, TReturnType extends keyof IReturnTypes<TNode>> (
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
 	variables?: { [s: string]: any } | null,
 	returnType?: TReturnType,
 	options?: Options | null
-): IReturnTypes[TReturnType] {
+): IReturnTypes<TNode>[TReturnType] {
 	returnType = returnType || (ReturnType.ANY as any);
 	if (!selector || typeof selector !== 'string') {
 		throw new TypeError("Failed to execute 'evaluateXPath': xpathExpression must be a string.");
@@ -514,25 +514,25 @@ function evaluateXPath<TReturnType extends keyof IReturnTypes> (
  * statically: XPaths returning empty sequences will return empty
  * arrays and not null, like one might expect.
  */
-evaluateXPath['ANY_TYPE'] = evaluateXPath.ANY_TYPE = ReturnType.ANY;
+evaluateXPath['ANY_TYPE'] = evaluateXPath.ANY_TYPE = ReturnType.ANY as ReturnType.ANY;
 
 /**
  * Resolve to a number, like count((1,2,3)) resolves to 3.
  */
-evaluateXPath['NUMBER_TYPE'] = evaluateXPath.NUMBER_TYPE = ReturnType.NUMBER;
+evaluateXPath['NUMBER_TYPE'] = evaluateXPath.NUMBER_TYPE = ReturnType.NUMBER as ReturnType.NUMBER;
 
 /**
  * Resolve to a string, like //someElement[1] resolves to the text
  * content of the first someElement
  */
-evaluateXPath['STRING_TYPE'] = evaluateXPath.STRING_TYPE = ReturnType.STRING;
+evaluateXPath['STRING_TYPE'] = evaluateXPath.STRING_TYPE = ReturnType.STRING as ReturnType.STRING;
 
 /**
  * Resolves to true or false, uses the effective boolean value to
  * determine the result. count(1) resolves to true, count(())
  * resolves to false
  */
-evaluateXPath['BOOLEAN_TYPE'] = evaluateXPath.BOOLEAN_TYPE = ReturnType.BOOLEAN;
+evaluateXPath['BOOLEAN_TYPE'] = evaluateXPath.BOOLEAN_TYPE = ReturnType.BOOLEAN as ReturnType.BOOLEAN;
 
 /**
  * Resolve to all nodes the XPath resolves to. Returns nodes in the
@@ -540,32 +540,32 @@ evaluateXPath['BOOLEAN_TYPE'] = evaluateXPath.BOOLEAN_TYPE = ReturnType.BOOLEAN;
  * followed by all B nodes. //*[self::a or self::b] resolves to A and
  * B nodes in document order.
  */
-evaluateXPath['NODES_TYPE'] = evaluateXPath.NODES_TYPE = ReturnType.NODES;
+evaluateXPath['NODES_TYPE'] = evaluateXPath.NODES_TYPE = ReturnType.NODES as ReturnType.NODES;
 
 /**
  * Resolves to the first node.NODES_TYPE would have resolved to.
  */
-evaluateXPath['FIRST_NODE_TYPE'] = evaluateXPath.FIRST_NODE_TYPE = ReturnType.FIRST_NODE;
+evaluateXPath['FIRST_NODE_TYPE'] = evaluateXPath.FIRST_NODE_TYPE = ReturnType.FIRST_NODE as ReturnType.FIRST_NODE;
 
 /**
  * Resolve to an array of strings
  */
-evaluateXPath['STRINGS_TYPE'] = evaluateXPath.STRINGS_TYPE = ReturnType.STRINGS;
+evaluateXPath['STRINGS_TYPE'] = evaluateXPath.STRINGS_TYPE = ReturnType.STRINGS as ReturnType.STRINGS;
 
 /**
  * Resolve to an object, as a map
  */
-evaluateXPath['MAP_TYPE'] = evaluateXPath.MAP_TYPE = ReturnType.MAP;
+evaluateXPath['MAP_TYPE'] = evaluateXPath.MAP_TYPE = ReturnType.MAP as ReturnType.MAP;
 
-evaluateXPath['ARRAY_TYPE'] = evaluateXPath.ARRAY_TYPE = ReturnType.ARRAY;
+evaluateXPath['ARRAY_TYPE'] = evaluateXPath.ARRAY_TYPE = ReturnType.ARRAY as ReturnType.ARRAY;
 
 evaluateXPath['ASYNC_ITERATOR_TYPE'] = evaluateXPath.ASYNC_ITERATOR_TYPE =
-	ReturnType.ASYNC_ITERATOR;
+	ReturnType.ASYNC_ITERATOR as ReturnType.ASYNC_ITERATOR;
 
 /**
  * Resolve to an array of numbers
  */
-evaluateXPath['NUMBERS_TYPE'] = evaluateXPath.NUMBERS_TYPE = ReturnType.NUMBERS;
+evaluateXPath['NUMBERS_TYPE'] = evaluateXPath.NUMBERS_TYPE = ReturnType.NUMBERS as ReturnType.NUMBERS;
 
 /**
  * @public

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -157,7 +157,10 @@ export enum ReturnType {
 	ASYNC_ITERATOR = 99
 }
 
-interface IReturnTypes {
+/**
+ * @public
+ */
+export interface IReturnTypes {
 	[ReturnType.ANY]: any;
 	[ReturnType.NUMBER]: number;
 	[ReturnType.STRING]: string;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -140,7 +140,10 @@ export type Options = {
 	nodesFactory?: INodesFactory;
 };
 
-enum ReturnType {
+/**
+ * @public
+ */
+export enum ReturnType {
 	ANY = 0,
 	NUMBER = 1,
 	STRING = 2,
@@ -190,7 +193,7 @@ interface IReturnTypes {
  *
  * @returns The result of executing this XPath
  */
-const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends keyof IReturnTypes>(
+const evaluateXPath = function _evaluateXPath<T extends Node, TReturnType extends keyof IReturnTypes>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
@@ -200,7 +203,7 @@ const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends
 ): IReturnTypes[TReturnType] {
 	returnType = returnType || ReturnType.ANY as any;
 	if (!selector || typeof selector !== 'string') {
-		throw new TypeError("Failed to execute 'evaluateXPath': xpathExpression must be a string.");
+		throw new TypeError("Failed to execute '_': xpathExpression must be a string.");
 	}
 
 	options = options || {};
@@ -502,23 +505,6 @@ const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends
 		printAndRethrowError(selector, error);
 	}
 };
-
-/**
- * @public
- */
-export enum ReturnType {
-	ANY = 0,
-	NUMBER = 1,
-	STRING = 2,
-	BOOLEAN = 3,
-	NODES = 7,
-	FIST_NODE = 9,
-	STRINGS = 10,
-	MAP = 11,
-	ARRAY = 12,
-	NUMBERS = 13,
-	ASYNC_ITERATOR = 99
-}
 
 /**
  * Returns the result of the query, can be anything depending on the

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -12,9 +12,7 @@ import Expression from './expressions/Expression';
 import { DONE_TOKEN, IterationHint, notReady, ready } from './expressions/util/iterators';
 import getBucketsForNode from './getBucketsForNode';
 import INodesFactory from './nodesFactory/INodesFactory';
-import IDomFacade from './domFacade/IDomFacade';
 import { Node } from './types/Types';
-import xPathParserRaw from './parsing/xPathParser.raw';
 
 function transformMapToObject(map, dynamicContext) {
 	const mapObj = {};
@@ -156,18 +154,18 @@ enum ReturnType {
 	ASYNC_ITERATOR = 99
 }
 
-interface ReturnTypes {
-	[ReturnType.ANY]: any,
-	[ReturnType.NUMBER]: number,
-	[ReturnType.STRING]: string,
-	[ReturnType.BOOLEAN]: boolean,
-	[ReturnType.NODES]: Node[],
-	[ReturnType.FIRST_NODE]: Node,
-	[ReturnType.STRINGS]: string[],
-	[ReturnType.MAP]: { [s: string]: any },
-	[ReturnType.ARRAY]: any[],
-	[ReturnType.NUMBERS]: number[],
-	[ReturnType.ASYNC_ITERATOR]: AsyncIterator<any>
+interface IReturnTypes {
+	[ReturnType.ANY]: any;
+	[ReturnType.NUMBER]: number;
+	[ReturnType.STRING]: string;
+	[ReturnType.BOOLEAN]: boolean;
+	[ReturnType.NODES]: Node[];
+	[ReturnType.FIRST_NODE]: Node;
+	[ReturnType.STRINGS]: string[];
+	[ReturnType.MAP]: { [s: string]: any };
+	[ReturnType.ARRAY]: any[];
+	[ReturnType.NUMBERS]: number[];
+	[ReturnType.ASYNC_ITERATOR]: AsyncIterator<any>;
 }
 
 
@@ -192,14 +190,14 @@ interface ReturnTypes {
  *
  * @returns The result of executing this XPath
  */
-const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends keyof ReturnTypes>(
+const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends keyof IReturnTypes>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
 	variables?: { [s: string]: any } | null,
 	returnType?: TReturnType,
 	options?: Options | null
-): ReturnTypes[TReturnType] {
+): IReturnTypes[TReturnType] {
 	returnType = returnType || ReturnType.ANY as any;
 	if (!selector || typeof selector !== 'string') {
 		throw new TypeError("Failed to execute 'evaluateXPath': xpathExpression must be a string.");
@@ -426,7 +424,7 @@ const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends
 						done: true,
 						value: null
 					});
-				}
+				};
 				if ('asyncIterator' in Symbol) {
 					return {
 						[Symbol.asyncIterator]() {
@@ -503,7 +501,7 @@ const evaluateXPath = function evaluateXPath<T extends Node, TReturnType extends
 	} catch (error) {
 		printAndRethrowError(selector, error);
 	}
-}
+};
 
 /**
  * @public

--- a/src/evaluateXPathToFirstNode.ts
+++ b/src/evaluateXPathToFirstNode.ts
@@ -1,5 +1,6 @@
 import IDomFacade from './domFacade/IDomFacade';
 import evaluateXPath, { Options } from './evaluateXPath';
+import { Node } from './types/Types';
 
 /**
  * Evaluates an XPath on the given contextNode. Returns the first node result.
@@ -14,13 +15,13 @@ import evaluateXPath, { Options } from './evaluateXPath';
  *
  * @returns The first matching node, in the order defined by the XPath.
  */
-export default function evaluateXPathToFirstNode(
+export default function evaluateXPathToFirstNode<T extends Node>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
 	variables?: { [s: string]: any } | null,
 	options?: Options | null
-): Node | null {
+): T | null {
 	return evaluateXPath(
 		selector,
 		contextItem,

--- a/src/evaluateXPathToFirstNode.ts
+++ b/src/evaluateXPathToFirstNode.ts
@@ -22,7 +22,7 @@ export default function evaluateXPathToFirstNode<T extends Node>(
 	variables?: { [s: string]: any } | null,
 	options?: Options | null
 ): T | null {
-	return evaluateXPath(
+	return evaluateXPath<T, evaluateXPath.FIRST_NODE_TYPE>(
 		selector,
 		contextItem,
 		domFacade,

--- a/src/evaluateXPathToNodes.ts
+++ b/src/evaluateXPathToNodes.ts
@@ -1,5 +1,6 @@
 import IDomFacade from './domFacade/IDomFacade';
 import evaluateXPath, { Options } from './evaluateXPath';
+import { Node } from './types/Types';
 
 /**
  * Evaluates an XPath on the given contextNode. Returns the first node result.
@@ -17,13 +18,13 @@ import evaluateXPath, { Options } from './evaluateXPath';
  *
  * @returns All matching Nodes, in the order defined by the XPath.
  */
-export default function evaluateXPathToNodes(
+export default function evaluateXPathToNodes<T extends Node = Node>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,
 	variables?: { [s: string]: any } | null,
 	options?: Options | null
-): Node[] {
+): T[] {
 	return evaluateXPath(
 		selector,
 		contextItem,

--- a/src/evaluateXPathToNodes.ts
+++ b/src/evaluateXPathToNodes.ts
@@ -18,7 +18,7 @@ import { Node } from './types/Types';
  *
  * @returns All matching Nodes, in the order defined by the XPath.
  */
-export default function evaluateXPathToNodes<T extends Node = Node>(
+export default function evaluateXPathToNodes<T extends Node>(
 	selector: string,
 	contextItem?: any | null,
 	domFacade?: IDomFacade | null,

--- a/src/evaluateXPathToNodes.ts
+++ b/src/evaluateXPathToNodes.ts
@@ -25,7 +25,7 @@ export default function evaluateXPathToNodes<T extends Node>(
 	variables?: { [s: string]: any } | null,
 	options?: Options | null
 ): T[] {
-	return evaluateXPath(
+	return evaluateXPath<T, evaluateXPath.NODES_TYPE>(
 		selector,
 		contextItem,
 		domFacade,

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -33,7 +33,7 @@ builtInFunctions.forEach(builtInFunction => {
 	);
 });
 
-function createDefaultNamespaceResolver(contextItem: Node | any): (s: string) => string {
+function createDefaultNamespaceResolver(contextItem: Node): (s: string) => string {
 	if (!contextItem || typeof contextItem !== 'object' || !('lookupNamespaceURI' in contextItem)) {
 		return _prefix => null;
 	}

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -33,11 +33,11 @@ builtInFunctions.forEach(builtInFunction => {
 	);
 });
 
-function createDefaultNamespaceResolver(contextItem: Node): (s: string) => string {
+function createDefaultNamespaceResolver(contextItem: any): (s: string) => string {
 	if (!contextItem || typeof contextItem !== 'object' || !('lookupNamespaceURI' in contextItem)) {
 		return _prefix => null;
 	}
-	return prefix => contextItem['lookupNamespaceURI'](prefix || null);
+	return prefix => (contextItem as Node)['lookupNamespaceURI'](prefix || null);
 }
 
 function normalizeEndOfLines(xpathString: string) {

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -18,6 +18,7 @@ import DomBackedNodesFactory from '../nodesFactory/DomBackedNodesFactory';
 import INodesFactory from '../nodesFactory/INodesFactory';
 import wrapExternalNodesFactory from '../nodesFactory/wrapExternalNodesFactory';
 import staticallyCompileXPath from '../parsing/staticallyCompileXPath';
+import { Node } from '../types/Types';
 
 export const generateGlobalVariableBindingName = (variableName: string) => `GLOBAL_${variableName}`;
 

--- a/src/expressions/DynamicContext.ts
+++ b/src/expressions/DynamicContext.ts
@@ -102,13 +102,9 @@ class DynamicContext {
 		);
 	}
 
-<<<<<<< HEAD
 	public scopeWithVariableBindings(variableBindings: {
 		[s: string]: () => ISequence;
 	}): DynamicContext {
-=======
-	public scopeWithVariableBindings(variableBindings: { [s: string]: () => ISequence }): DynamicContext {
->>>>>>> Start on fixing tests
 		return new DynamicContext(
 			{
 				contextItem: this.contextItem,

--- a/src/expressions/DynamicContext.ts
+++ b/src/expressions/DynamicContext.ts
@@ -2,7 +2,7 @@ import ISequence from './dataTypes/ISequence';
 import Value from './dataTypes/Value';
 import DateTime from './dataTypes/valueTypes/DateTime';
 import DayTimeDuration from './dataTypes/valueTypes/DayTimeDuration';
-import { IAsyncIterator, IterationHint, ready } from './util/iterators';
+import { IAsyncIterator, IterationHint, notReady, ready } from './util/iterators';
 
 type TemporalContext = {
 	currentDateTime: DateTime | null;
@@ -59,7 +59,7 @@ class DynamicContext {
 					return value;
 				}
 				if (!value.ready) {
-					return value;
+					return notReady(value.promise);
 				}
 				return ready(this.scopeWithFocus(i++, value.value, contextSequence));
 			}

--- a/src/expressions/DynamicContext.ts
+++ b/src/expressions/DynamicContext.ts
@@ -2,16 +2,16 @@ import ISequence from './dataTypes/ISequence';
 import Value from './dataTypes/Value';
 import DateTime from './dataTypes/valueTypes/DateTime';
 import DayTimeDuration from './dataTypes/valueTypes/DayTimeDuration';
-import { AsyncIterator, IterationHint, ready } from './util/iterators';
+import { IAsyncIterator, IterationHint, ready } from './util/iterators';
 
 type TemporalContext = {
-	currentDateTime: DateTime;
-	implicitTimezone: DayTimeDuration;
+	currentDateTime: DateTime | null;
+	implicitTimezone: DayTimeDuration | null;
 	isInitialized: boolean;
 };
 
 class DynamicContext {
-	public contextItem: Value;
+	public contextItem: Value | null;
 	public contextItemIndex: number;
 	public contextSequence: ISequence;
 	public variableBindings: { [s: string]: () => ISequence };
@@ -49,7 +49,7 @@ class DynamicContext {
 		this.variableBindings = context.variableBindings || Object.create(null);
 	}
 
-	public createSequenceIterator(contextSequence: ISequence): AsyncIterator<DynamicContext> {
+	public createSequenceIterator(contextSequence: ISequence): IAsyncIterator<DynamicContext> {
 		let i = 0;
 		const iterator = contextSequence.value;
 		return {
@@ -102,9 +102,13 @@ class DynamicContext {
 		);
 	}
 
+<<<<<<< HEAD
 	public scopeWithVariableBindings(variableBindings: {
 		[s: string]: () => ISequence;
 	}): DynamicContext {
+=======
+	public scopeWithVariableBindings(variableBindings: { [s: string]: () => ISequence }): DynamicContext {
+>>>>>>> Start on fixing tests
 		return new DynamicContext(
 			{
 				contextItem: this.contextItem,

--- a/src/expressions/DynamicContext.ts
+++ b/src/expressions/DynamicContext.ts
@@ -88,7 +88,7 @@ class DynamicContext {
 
 	public scopeWithFocus(
 		contextItemIndex: number,
-		contextItem: Value|null,
+		contextItem: Value | null,
 		contextSequence: ISequence
 	): DynamicContext {
 		return new DynamicContext(

--- a/src/expressions/DynamicContext.ts
+++ b/src/expressions/DynamicContext.ts
@@ -88,7 +88,7 @@ class DynamicContext {
 
 	public scopeWithFocus(
 		contextItemIndex: number,
-		contextItem: Value,
+		contextItem: Value|null,
 		contextSequence: ISequence
 	): DynamicContext {
 		return new DynamicContext(

--- a/src/expressions/ExecutionSpecificStaticContext.ts
+++ b/src/expressions/ExecutionSpecificStaticContext.ts
@@ -17,13 +17,13 @@ export const generateGlobalVariableBindingName = (variableName: string) => `GLOB
 export default class ExecutionSpecificStaticContext implements IContext {
 	public executionContextWasRequired: boolean;
 
-	private _namespaceResolver: any;
-	private _referredNamespaceByName: any;
-	private _referredVariableByName: any;
-	private _variableBindingByName: any;
+	private _namespaceResolver: (namespaceURI: string) => null | string;
+	private _referredNamespaceByName: {[prefix: string]: {localName: string; namespaceURI: string}};
+	private _referredVariableByName: {[variable: string]: {localName: string; namespaceURI: string}};
+	private _variableBindingByName: {[variableName: string]: string};
 	private _variableValueByName: any;
 
-	constructor(namespaceResolver, variableByName) {
+	constructor(namespaceResolver: (prefix: string) => string | null, variableByName: object) {
 		this._namespaceResolver = namespaceResolver;
 		this._variableBindingByName = Object.keys(variableByName).reduce(
 			(bindings, variableName) => {
@@ -48,11 +48,11 @@ export default class ExecutionSpecificStaticContext implements IContext {
 		this.executionContextWasRequired = false;
 	}
 
-	public getReferredNamespaces(): string[] {
+	public getReferredNamespaces(): {localName: string; namespaceURI: string}[] {
 		return Object.values(this._referredNamespaceByName);
 	}
 
-	public getReferredVariables(): string[] {
+	public getReferredVariables(): {localName: string; namespaceURI: string}[] {
 		return Object.values(this._referredVariableByName);
 	}
 

--- a/src/expressions/ExecutionSpecificStaticContext.ts
+++ b/src/expressions/ExecutionSpecificStaticContext.ts
@@ -18,9 +18,13 @@ export default class ExecutionSpecificStaticContext implements IContext {
 	public executionContextWasRequired: boolean;
 
 	private _namespaceResolver: (namespaceURI: string) => null | string;
-	private _referredNamespaceByName: {[prefix: string]: {localName: string; namespaceURI: string}};
-	private _referredVariableByName: {[variable: string]: {localName: string; namespaceURI: string}};
-	private _variableBindingByName: {[variableName: string]: string};
+	private _referredNamespaceByName: {
+		[prefix: string]: { localName: string; namespaceURI: string };
+	};
+	private _referredVariableByName: {
+		[variable: string]: { localName: string; namespaceURI: string };
+	};
+	private _variableBindingByName: { [variableName: string]: string };
 	private _variableValueByName: any;
 
 	constructor(namespaceResolver: (prefix: string) => string | null, variableByName: object) {
@@ -48,11 +52,11 @@ export default class ExecutionSpecificStaticContext implements IContext {
 		this.executionContextWasRequired = false;
 	}
 
-	public getReferredNamespaces(): {localName: string; namespaceURI: string}[] {
+	public getReferredNamespaces(): { localName: string; namespaceURI: string }[] {
 		return Object.values(this._referredNamespaceByName);
 	}
 
-	public getReferredVariables(): {localName: string; namespaceURI: string}[] {
+	public getReferredVariables(): { localName: string; namespaceURI: string }[] {
 		return Object.values(this._referredVariableByName);
 	}
 

--- a/src/expressions/ForExpression.ts
+++ b/src/expressions/ForExpression.ts
@@ -5,13 +5,8 @@ import DynamicContext from './DynamicContext';
 import ExecutionParameters from './ExecutionParameters';
 import Expression from './Expression';
 import PossiblyUpdatingExpression from './PossiblyUpdatingExpression';
-<<<<<<< HEAD
 import StaticContext from './StaticContext';
-import { AsyncIterator, DONE_TOKEN, IterationHint } from './util/iterators';
-=======
-import { DONE_TOKEN } from './util/iterators';
-import StaticContext from './StaticContext';
->>>>>>> Start on typing variables
+import { DONE_TOKEN, IAsyncIterator, IterationHint } from './util/iterators';
 
 class ForExpression extends PossiblyUpdatingExpression {
 	private _clauseExpression: Expression;
@@ -55,7 +50,7 @@ class ForExpression extends PossiblyUpdatingExpression {
 			dynamicContext,
 			executionParameters
 		).value;
-		let returnIterator: AsyncIterator<Value> | null = null;
+		let returnIterator: IAsyncIterator<Value> | null = null;
 		let done = false;
 		return sequenceFactory.create({
 			next: (hint: IterationHint) => {

--- a/src/expressions/ForExpression.ts
+++ b/src/expressions/ForExpression.ts
@@ -5,8 +5,13 @@ import DynamicContext from './DynamicContext';
 import ExecutionParameters from './ExecutionParameters';
 import Expression from './Expression';
 import PossiblyUpdatingExpression from './PossiblyUpdatingExpression';
+<<<<<<< HEAD
 import StaticContext from './StaticContext';
 import { AsyncIterator, DONE_TOKEN, IterationHint } from './util/iterators';
+=======
+import { DONE_TOKEN } from './util/iterators';
+import StaticContext from './StaticContext';
+>>>>>>> Start on typing variables
 
 class ForExpression extends PossiblyUpdatingExpression {
 	private _clauseExpression: Expression;

--- a/src/expressions/LetExpression.ts
+++ b/src/expressions/LetExpression.ts
@@ -41,9 +41,9 @@ class LetExpression extends PossiblyUpdatingExpression {
 	}
 
 	public performFunctionalEvaluation(
-		dynamicContext,
-		_executionParameters,
-		[createBindingSequence, createReturnExpression]
+		dynamicContext: DynamicContext,
+		_executionParameters: ExecutionParameters,
+		[_createBindingSequence, createReturnExpression]: SequenceCallbacks
 	) {
 		const scopedContext = dynamicContext.scopeWithVariableBindings({
 			[this._variableBinding]: createDoublyIterableSequence(

--- a/src/expressions/LetExpression.ts
+++ b/src/expressions/LetExpression.ts
@@ -8,10 +8,10 @@ import createDoublyIterableSequence from './util/createDoublyIterableSequence';
 class LetExpression extends PossiblyUpdatingExpression {
 	public _bindingSequence: Expression;
 	public _localName: string;
-	public _namespaceURI: string|null;
+	public _namespaceURI: string | null;
 	public _prefix: string;
 	public _returnExpression: Expression;
-	public _variableBinding:  string|null;
+	public _variableBinding: string | null;
 
 	constructor(
 		rangeVariable: { localName: string; namespaceURI: string | null; prefix: string },
@@ -49,7 +49,7 @@ class LetExpression extends PossiblyUpdatingExpression {
 		[createBindingSequence, createReturnExpression]: SequenceCallbacks
 	) {
 		const scopedContext = dynamicContext.scopeWithVariableBindings({
-			[this._variableBinding!]: createDoublyIterableSequence(
+			[this._variableBinding]: createDoublyIterableSequence(
 				createBindingSequence(dynamicContext)
 			)
 		});

--- a/src/expressions/LetExpression.ts
+++ b/src/expressions/LetExpression.ts
@@ -1,14 +1,17 @@
+import DynamicContext from './DynamicContext';
+import ExecutionParameters from './ExecutionParameters';
 import Expression from './Expression';
-import PossiblyUpdatingExpression from './PossiblyUpdatingExpression';
+import PossiblyUpdatingExpression, { SequenceCallbacks } from './PossiblyUpdatingExpression';
+import StaticContext from './StaticContext';
 import createDoublyIterableSequence from './util/createDoublyIterableSequence';
 
 class LetExpression extends PossiblyUpdatingExpression {
 	public _bindingSequence: Expression;
 	public _localName: string;
-	public _namespaceURI: string;
+	public _namespaceURI: string|null;
 	public _prefix: string;
 	public _returnExpression: Expression;
-	public _variableBinding: any;
+	public _variableBinding:  string|null;
 
 	constructor(
 		rangeVariable: { localName: string; namespaceURI: string | null; prefix: string },
@@ -43,10 +46,10 @@ class LetExpression extends PossiblyUpdatingExpression {
 	public performFunctionalEvaluation(
 		dynamicContext: DynamicContext,
 		_executionParameters: ExecutionParameters,
-		[_createBindingSequence, createReturnExpression]: SequenceCallbacks
+		[createBindingSequence, createReturnExpression]: SequenceCallbacks
 	) {
 		const scopedContext = dynamicContext.scopeWithVariableBindings({
-			[this._variableBinding]: createDoublyIterableSequence(
+			[this._variableBinding!]: createDoublyIterableSequence(
 				createBindingSequence(dynamicContext)
 			)
 		});
@@ -54,7 +57,7 @@ class LetExpression extends PossiblyUpdatingExpression {
 		return createReturnExpression(scopedContext);
 	}
 
-	public performStaticEvaluation(staticContext) {
+	public performStaticEvaluation(staticContext: StaticContext) {
 		if (this._prefix) {
 			this._namespaceURI = staticContext.resolveNamespace(this._prefix);
 

--- a/src/expressions/PossiblyUpdatingExpression.ts
+++ b/src/expressions/PossiblyUpdatingExpression.ts
@@ -6,7 +6,11 @@ import ExecutionParameters from './ExecutionParameters';
 import Expression, { OptimizationOptions } from './Expression';
 import Specificity from './Specificity';
 import UpdatingExpressionResult from './UpdatingExpressionResult';
+<<<<<<< HEAD
 import { AsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from './util/iterators';
+=======
+import { DONE_TOKEN, IAsyncIterator, notReady, ready } from './util/iterators';
+>>>>>>> Start on fixing tests
 import { mergeUpdates } from './xquery-update/pulRoutines';
 import UpdatingExpression from './xquery-update/UpdatingExpression';
 
@@ -37,7 +41,7 @@ export default abstract class PossiblyUpdatingExpression extends Expression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
+	): IAsyncIterator<UpdatingExpressionResult> {
 		let updateList = [];
 
 		const sequence = this.performFunctionalEvaluation(

--- a/src/expressions/PossiblyUpdatingExpression.ts
+++ b/src/expressions/PossiblyUpdatingExpression.ts
@@ -6,11 +6,7 @@ import ExecutionParameters from './ExecutionParameters';
 import Expression, { OptimizationOptions } from './Expression';
 import Specificity from './Specificity';
 import UpdatingExpressionResult from './UpdatingExpressionResult';
-<<<<<<< HEAD
-import { AsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from './util/iterators';
-=======
-import { DONE_TOKEN, IAsyncIterator, notReady, ready } from './util/iterators';
->>>>>>> Start on fixing tests
+import { IAsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from './util/iterators';
 import { mergeUpdates } from './xquery-update/pulRoutines';
 import UpdatingExpression from './xquery-update/UpdatingExpression';
 

--- a/src/expressions/PossiblyUpdatingExpression.ts
+++ b/src/expressions/PossiblyUpdatingExpression.ts
@@ -10,6 +10,7 @@ import { AsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from './uti
 import { mergeUpdates } from './xquery-update/pulRoutines';
 import UpdatingExpression from './xquery-update/UpdatingExpression';
 
+export type SequenceCallbacks = ((dynamicContext: DynamicContext) => ISequence)[];
 export default abstract class PossiblyUpdatingExpression extends Expression {
 	constructor(
 		specificity: Specificity,
@@ -107,6 +108,6 @@ export default abstract class PossiblyUpdatingExpression extends Expression {
 	public abstract performFunctionalEvaluation(
 		_dynamicContext: DynamicContext,
 		_executionParameters: ExecutionParameters,
-		_sequenceCallbacks: ((dynamicContext: DynamicContext) => ISequence)[]
+		_sequenceCallbacks: SequenceCallbacks
 	): ISequence;
 }

--- a/src/expressions/PossiblyUpdatingExpression.ts
+++ b/src/expressions/PossiblyUpdatingExpression.ts
@@ -6,7 +6,7 @@ import ExecutionParameters from './ExecutionParameters';
 import Expression, { OptimizationOptions } from './Expression';
 import Specificity from './Specificity';
 import UpdatingExpressionResult from './UpdatingExpressionResult';
-import { IAsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from './util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, notReady, ready } from './util/iterators';
 import { mergeUpdates } from './xquery-update/pulRoutines';
 import UpdatingExpression from './xquery-update/UpdatingExpression';
 

--- a/src/expressions/StaticContext.ts
+++ b/src/expressions/StaticContext.ts
@@ -1,5 +1,7 @@
 import IContext from './Context';
 import { FunctionProperties } from './functions/functionRegistry';
+import TypeDeclaration from './dataTypes/TypeDeclaration';
+import FunctionDefinitionType from './functions/FunctionDefinitionType';
 
 function createHashKey(namespaceURI: any, localName: any) {
 	return `Q{${namespaceURI || ''}}${localName}`;
@@ -14,6 +16,15 @@ function lookupInOverrides(overrides: any[] | { [x: string]: any }[], key: strin
 	}
 
 	return undefined;
+}
+
+export type FunctionDefinition = {
+	argumentTypes: TypeDeclaration[];
+	arity: number;
+	callFunction: FunctionDefinitionType
+	localName: string;
+	namespaceURI: string;
+	returnType: TypeDeclaration;
 }
 
 /**
@@ -111,19 +122,7 @@ export default class StaticContext {
 		namespaceURI: string,
 		localName: string,
 		arity: number,
-		functionDefinition: {
-			argumentTypes: import('./dataTypes/TypeDeclaration').default[];
-			arity: number;
-			callFunction: (
-				dynamicContext: any,
-				executionParameters: any,
-				_staticContext: any,
-				...parameters: any[]
-			) => import('./dataTypes/ISequence').default;
-			localName: string;
-			namespaceURI: string;
-			returnType: import('./dataTypes/TypeDeclaration').default;
-		}
+		functionDefinition: FunctionDefinition
 	) {
 		const hashKey = createHashKey(namespaceURI, localName) + '~' + arity;
 		const duplicateFunction = this._registeredFunctionsByHash[hashKey];
@@ -144,8 +143,8 @@ export default class StaticContext {
 	 * We need this to separate variable declaration (which is required to be done statically) and
 	 * from when the dynamic context of the variable will be known.
 	 */
-	public registerVariable(namespaceURI: string, localName: string) {
-		const hash = createHashKey(namespaceURI, localName);
+	public registerVariable(namespaceURI: string|null, localName: string) {
+		const hash = createHashKey(namespaceURI || '', localName);
 		return (this._registeredVariableBindingByHashKey[this._scopeDepth][hash] = `${hash}[${
 			this._scopeCount
 		}]`);

--- a/src/expressions/StaticContext.ts
+++ b/src/expressions/StaticContext.ts
@@ -1,7 +1,7 @@
 import IContext from './Context';
-import { FunctionProperties } from './functions/functionRegistry';
 import TypeDeclaration from './dataTypes/TypeDeclaration';
 import FunctionDefinitionType from './functions/FunctionDefinitionType';
+import { FunctionProperties } from './functions/functionRegistry';
 
 function createHashKey(namespaceURI: any, localName: any) {
 	return `Q{${namespaceURI || ''}}${localName}`;
@@ -21,11 +21,11 @@ function lookupInOverrides(overrides: any[] | { [x: string]: any }[], key: strin
 export type FunctionDefinition = {
 	argumentTypes: TypeDeclaration[];
 	arity: number;
-	callFunction: FunctionDefinitionType
+	callFunction: FunctionDefinitionType;
 	localName: string;
 	namespaceURI: string;
 	returnType: TypeDeclaration;
-}
+};
 
 /**
  * The static context consists of all information that is available at compile time: the globally
@@ -143,7 +143,7 @@ export default class StaticContext {
 	 * We need this to separate variable declaration (which is required to be done statically) and
 	 * from when the dynamic context of the variable will be known.
 	 */
-	public registerVariable(namespaceURI: string|null, localName: string) {
+	public registerVariable(namespaceURI: string | null, localName: string) {
 		const hash = createHashKey(namespaceURI || '', localName);
 		return (this._registeredVariableBindingByHashKey[this._scopeDepth][hash] = `${hash}[${
 			this._scopeCount

--- a/src/expressions/axes/DescendantAxis.ts
+++ b/src/expressions/axes/DescendantAxis.ts
@@ -10,12 +10,12 @@ import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
 import createChildGenerator from '../util/createChildGenerator';
 import createSingleValueIterator from '../util/createSingleValueIterator';
-import { AsyncIterator, DONE_TOKEN, IterationHint, ready } from '../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, ready } from '../util/iterators';
 
 function createInclusiveDescendantGenerator(
 	domFacade: IDomFacade,
 	node: ConcreteChildNode
-): AsyncIterator<Value> {
+): IAsyncIterator<Value> {
 	const descendantIteratorStack: Iterator<ConcreteChildNode>[] = [
 		createSingleValueIterator(node)
 	];
@@ -32,13 +32,13 @@ function createInclusiveDescendantGenerator(
 			if (!descendantIteratorStack.length) {
 				return DONE_TOKEN;
 			}
-			let value = descendantIteratorStack[0].next();
+			let value = descendantIteratorStack[0].next(IterationHint.NONE);
 			while (value.done) {
 				descendantIteratorStack.shift();
 				if (!descendantIteratorStack.length) {
 					return DONE_TOKEN;
 				}
-				value = descendantIteratorStack[0].next();
+				value = descendantIteratorStack[0].next(IterationHint.NONE);
 			}
 			// Iterator over these children next
 			descendantIteratorStack.unshift(createChildGenerator(domFacade, value.value));

--- a/src/expressions/axes/DescendantAxis.ts
+++ b/src/expressions/axes/DescendantAxis.ts
@@ -16,7 +16,7 @@ function createInclusiveDescendantGenerator(
 	domFacade: IDomFacade,
 	node: ConcreteChildNode
 ): IAsyncIterator<Value> {
-	const descendantIteratorStack: Iterator<ConcreteChildNode>[] = [
+	const descendantIteratorStack: IAsyncIterator<ConcreteChildNode>[] = [
 		createSingleValueIterator(node)
 	];
 	return {

--- a/src/expressions/axes/FollowingAxis.ts
+++ b/src/expressions/axes/FollowingAxis.ts
@@ -3,7 +3,7 @@ import Expression, { RESULT_ORDERINGS } from '../Expression';
 import createNodeValue from '../dataTypes/createNodeValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
-import { DONE_TOKEN, ready } from '../util/iterators';
+import { DONE_TOKEN, IterationHint, ready } from '../util/iterators';
 
 import createDescendantGenerator from '../util/createDescendantGenerator';
 
@@ -37,7 +37,7 @@ function createFollowingGenerator(domFacade, node) {
 					return toReturn;
 				}
 
-				const nephew = nephewGenerator.next();
+				const nephew = nephewGenerator.next(IterationHint.NONE);
 
 				if (nephew.done) {
 					// We are done with the descendants of the node currently on the stack

--- a/src/expressions/axes/PrecedingAxis.ts
+++ b/src/expressions/axes/PrecedingAxis.ts
@@ -58,10 +58,10 @@ class PrecedingAxis extends Expression {
 	private _testExpression: TestAbstractExpression;
 	constructor(testExpression: TestAbstractExpression) {
 		super(testExpression.specificity, [testExpression], {
-			resultOrder: RESULT_ORDERINGS.REVERSE_SORTED,
+			canBeStaticallyEvaluated: false,
 			peer: true,
-			subtree: false,
-			canBeStaticallyEvaluated: false
+			resultOrder: RESULT_ORDERINGS.REVERSE_SORTED,
+			subtree: false
 		});
 
 		this._testExpression = testExpression;

--- a/src/expressions/axes/PrecedingAxis.ts
+++ b/src/expressions/axes/PrecedingAxis.ts
@@ -2,7 +2,7 @@ import Expression, { RESULT_ORDERINGS } from '../Expression';
 
 import createNodeValue from '../dataTypes/createNodeValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import { DONE_TOKEN, ready } from '../util/iterators';
+import { DONE_TOKEN, IterationHint, ready } from '../util/iterators';
 
 import TestAbstractExpression from '../tests/TestAbstractExpression';
 import createDescendantGenerator from '../util/createDescendantGenerator';
@@ -26,7 +26,7 @@ function createPrecedingGenerator(domFacade, node) {
 					nephewGenerator = createDescendantGenerator(domFacade, nodeStack[0], true);
 				}
 
-				const nephew = nephewGenerator.next();
+				const nephew = nephewGenerator.next(IterationHint.NONE);
 
 				if (nephew.done) {
 					// We are done with the descendants of the node currently on the stack

--- a/src/expressions/conditional/IfExpression.ts
+++ b/src/expressions/conditional/IfExpression.ts
@@ -1,12 +1,17 @@
 import Expression, { RESULT_ORDERINGS } from '../Expression';
-import PossiblyUpdatingExpression from '../PossiblyUpdatingExpression';
+import PossiblyUpdatingExpression, { SequenceCallbacks } from '../PossiblyUpdatingExpression';
 
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+<<<<<<< HEAD
 import Value from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import { AsyncIterator, IterationHint, notReady } from '../util/iterators';
+=======
+import DynamicContext from '../DynamicContext';
+import ExecutionParameters from '../ExecutionParameters';
+>>>>>>> Start on typing variables
 
 class IfExpression extends PossiblyUpdatingExpression {
 	constructor(
@@ -36,7 +41,7 @@ class IfExpression extends PossiblyUpdatingExpression {
 		_executionParameters: ExecutionParameters,
 		sequenceCallbacks: ((dynamicContext: DynamicContext) => ISequence)[]
 	) {
-		let resultIterator: AsyncIterator<Value> = null;
+		let resultIterator: AsyncIterator<Value> | null = null;
 		const ifExpressionResultSequence = sequenceCallbacks[0](dynamicContext);
 
 		return sequenceFactory.create({

--- a/src/expressions/conditional/IfExpression.ts
+++ b/src/expressions/conditional/IfExpression.ts
@@ -1,5 +1,5 @@
 import Expression, { RESULT_ORDERINGS } from '../Expression';
-import PossiblyUpdatingExpression, { SequenceCallbacks } from '../PossiblyUpdatingExpression';
+import PossiblyUpdatingExpression from '../PossiblyUpdatingExpression';
 
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';

--- a/src/expressions/conditional/IfExpression.ts
+++ b/src/expressions/conditional/IfExpression.ts
@@ -3,15 +3,10 @@ import PossiblyUpdatingExpression, { SequenceCallbacks } from '../PossiblyUpdati
 
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-<<<<<<< HEAD
 import Value from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
-import { AsyncIterator, IterationHint, notReady } from '../util/iterators';
-=======
-import DynamicContext from '../DynamicContext';
-import ExecutionParameters from '../ExecutionParameters';
->>>>>>> Start on typing variables
+import { IAsyncIterator, IterationHint, notReady } from '../util/iterators';
 
 class IfExpression extends PossiblyUpdatingExpression {
 	constructor(
@@ -41,7 +36,7 @@ class IfExpression extends PossiblyUpdatingExpression {
 		_executionParameters: ExecutionParameters,
 		sequenceCallbacks: ((dynamicContext: DynamicContext) => ISequence)[]
 	) {
-		let resultIterator: AsyncIterator<Value> | null = null;
+		let resultIterator: IAsyncIterator<Value> | null = null;
 		const ifExpressionResultSequence = sequenceCallbacks[0](dynamicContext);
 
 		return sequenceFactory.create({

--- a/src/expressions/dataTypes/ISequence.ts
+++ b/src/expressions/dataTypes/ISequence.ts
@@ -1,5 +1,5 @@
 import ExecutionParameters from '../ExecutionParameters';
-import { AsyncIterator, AsyncResult, IterationHint } from '../util/iterators';
+import { IAsyncIterator, IAsyncResult, IterationHint } from '../util/iterators';
 import Value from './Value';
 
 type SwitchCasesCaseEmpty = {
@@ -36,7 +36,7 @@ export type SwitchCasesCases =
 	| SwitchCasesCaseAll;
 
 export default interface ISequence {
-	value: AsyncIterator<Value>;
+	value: IAsyncIterator<Value>;
 
 	atomize(executionParameters: ExecutionParameters): ISequence;
 	expandSequence(): ISequence;
@@ -52,8 +52,8 @@ export default interface ISequence {
 	mapAll(callback: (allValues: Value[]) => ISequence, hint?: IterationHint): ISequence;
 	switchCases(cases: SwitchCasesCases): ISequence;
 
-	tryGetAllValues(): AsyncResult<Value[]>;
-	tryGetEffectiveBooleanValue(): AsyncResult<boolean>;
-	tryGetFirst(): AsyncResult<Value | null>;
-	tryGetLength(onlyIfCheap?: boolean): AsyncResult<number>;
+	tryGetAllValues(): IAsyncResult<Value[]>;
+	tryGetEffectiveBooleanValue(): IAsyncResult<boolean>;
+	tryGetFirst(): IAsyncResult<Value | null>;
+	tryGetLength(onlyIfCheap?: boolean): IAsyncResult<number>;
 }

--- a/src/expressions/dataTypes/Sequences/ArrayBackedSequence.ts
+++ b/src/expressions/dataTypes/Sequences/ArrayBackedSequence.ts
@@ -1,6 +1,6 @@
 import ExecutionParameters from '../../ExecutionParameters';
 import { errFORG0006 } from '../../functions/FunctionOperationErrors';
-import { AsyncIterator, AsyncResult, DONE_TOKEN, ready } from '../../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IAsyncResult, ready } from '../../util/iterators';
 import atomize from '../atomize';
 import ISequence, { SwitchCasesCases } from '../ISequence';
 import isSubtypeOf from '../isSubtypeOf';
@@ -8,7 +8,7 @@ import sequenceFactory from '../sequenceFactory';
 import Value from '../Value';
 
 export default class ArrayBackedSequence implements ISequence {
-	public value: AsyncIterator<Value>;
+	public value: IAsyncIterator<Value>;
 
 	constructor(
 		private readonly _sequenceFactory: typeof sequenceFactory,
@@ -101,19 +101,19 @@ export default class ArrayBackedSequence implements ISequence {
 		return cases.default(this);
 	}
 
-	public tryGetAllValues(): AsyncResult<Value[]> {
+	public tryGetAllValues(): IAsyncResult<Value[]> {
 		return ready(this.getAllValues());
 	}
 
-	public tryGetEffectiveBooleanValue(): AsyncResult<boolean> {
+	public tryGetEffectiveBooleanValue(): IAsyncResult<boolean> {
 		return ready(this.getEffectiveBooleanValue());
 	}
 
-	public tryGetFirst(): AsyncResult<Value> {
+	public tryGetFirst(): IAsyncResult<Value> {
 		return ready(this.first());
 	}
 
-	public tryGetLength(): AsyncResult<number> {
+	public tryGetLength(): IAsyncResult<number> {
 		return ready(this._values.length);
 	}
 }

--- a/src/expressions/dataTypes/Sequences/EmptySequence.ts
+++ b/src/expressions/dataTypes/Sequences/EmptySequence.ts
@@ -1,10 +1,10 @@
 import ExecutionParameters from '../../ExecutionParameters';
-import { AsyncIterator, AsyncResult, DONE_TOKEN, ready } from '../../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IAsyncResult, ready } from '../../util/iterators';
 import ISequence, { SwitchCasesCases } from '../ISequence';
 import Value from '../Value';
 
 export default class EmptySequence implements ISequence {
-	public value: AsyncIterator<Value>;
+	public value: IAsyncIterator<Value>;
 
 	constructor() {
 		this.value = {
@@ -59,19 +59,19 @@ export default class EmptySequence implements ISequence {
 		return cases.default(this);
 	}
 
-	public tryGetAllValues(): AsyncResult<Value[]> {
+	public tryGetAllValues(): IAsyncResult<Value[]> {
 		return ready(this.getAllValues());
 	}
 
-	public tryGetEffectiveBooleanValue(): AsyncResult<boolean> {
+	public tryGetEffectiveBooleanValue(): IAsyncResult<boolean> {
 		return ready(this.getEffectiveBooleanValue());
 	}
 
-	public tryGetFirst(): AsyncResult<Value> {
+	public tryGetFirst(): IAsyncResult<Value> {
 		return ready(this.first());
 	}
 
-	public tryGetLength(): AsyncResult<number> {
+	public tryGetLength(): IAsyncResult<number> {
 		return ready(0);
 	}
 }

--- a/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
+++ b/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
@@ -1,9 +1,9 @@
 import ExecutionParameters from '../../ExecutionParameters';
 import { errFORG0006 } from '../../functions/FunctionOperationErrors';
 import {
-	AsyncResult,
 	DONE_TOKEN,
 	IAsyncIterator,
+	IAsyncResult,
 	IterationHint,
 	notReady,
 	ready
@@ -150,7 +150,7 @@ export default class IteratorBackedSequence implements ISequence {
 
 	public mapAll(callback: (allValues: Value[]) => ISequence, hint: IterationHint): ISequence {
 		const iterator = this.value;
-		let mappedResultsIterator: AsyncIterator<Value>;
+		let mappedResultsIterator: IAsyncIterator<Value>;
 		const allResults: Value[] = [];
 		let isReady = false;
 		let readyPromise = null;
@@ -176,13 +176,13 @@ export default class IteratorBackedSequence implements ISequence {
 				if (!isReady) {
 					return notReady(readyPromise);
 				}
-				return mappedResultsIterator.next(IterationHint.NONE);
+				return mappedResultsIterator.next(hint);
 			}
 		});
 	}
 
 	public switchCases(cases: SwitchCasesCases): ISequence {
-		let resultIterator: AsyncIterator<Value> = null;
+		let resultIterator: IAsyncIterator<Value> = null;
 
 		const setResultIterator = (resultSequence: ISequence) => {
 			resultIterator = resultSequence.value;

--- a/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
+++ b/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
@@ -176,7 +176,7 @@ export default class IteratorBackedSequence implements ISequence {
 				if (!isReady) {
 					return notReady(readyPromise);
 				}
-				return mappedResultsIterator.next(hint);
+				return mappedResultsIterator.next(IterationHint.NONE);
 			}
 		});
 	}

--- a/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
+++ b/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
@@ -1,9 +1,9 @@
 import ExecutionParameters from '../../ExecutionParameters';
 import { errFORG0006 } from '../../functions/FunctionOperationErrors';
 import {
-	AsyncIterator,
 	AsyncResult,
 	DONE_TOKEN,
+	IAsyncIterator,
 	IterationHint,
 	notReady,
 	ready
@@ -16,7 +16,7 @@ import Value from '../Value';
 import getEffectiveBooleanValue from './getEffectiveBooleanValue';
 
 export default class IteratorBackedSequence implements ISequence {
-	public value: AsyncIterator<Value>;
+	public value: IAsyncIterator<Value>;
 
 	private _cacheAllValues: boolean;
 	private _cachedValues: Value[];
@@ -25,7 +25,7 @@ export default class IteratorBackedSequence implements ISequence {
 
 	constructor(
 		private readonly _sequenceFactory: typeof sequenceFactory,
-		valueIterator: AsyncIterator<Value>,
+		valueIterator: IAsyncIterator<Value>,
 		predictedLength: number = null
 	) {
 		this.value = {
@@ -225,7 +225,7 @@ export default class IteratorBackedSequence implements ISequence {
 		});
 	}
 
-	public tryGetAllValues(): AsyncResult<Value[]> {
+	public tryGetAllValues(): IAsyncResult<Value[]> {
 		if (
 			this._currentPosition > this._cachedValues.length &&
 			this._length !== this._cachedValues.length
@@ -248,7 +248,7 @@ export default class IteratorBackedSequence implements ISequence {
 		return ready(this._cachedValues);
 	}
 
-	public tryGetEffectiveBooleanValue(): AsyncResult<boolean> {
+	public tryGetEffectiveBooleanValue(): IAsyncResult<boolean> {
 		const iterator = this.value;
 		const oldPosition = this._currentPosition;
 
@@ -280,7 +280,7 @@ export default class IteratorBackedSequence implements ISequence {
 		return ready(getEffectiveBooleanValue(firstValue));
 	}
 
-	public tryGetFirst(): AsyncResult<Value> {
+	public tryGetFirst(): IAsyncResult<Value> {
 		if (this._cachedValues[0] !== undefined) {
 			return ready(this._cachedValues[0]);
 		}
@@ -300,7 +300,7 @@ export default class IteratorBackedSequence implements ISequence {
 		return firstValue;
 	}
 
-	public tryGetLength(onlyIfCheap = false): AsyncResult<number> {
+	public tryGetLength(onlyIfCheap = false): IAsyncResult<number> {
 		if (this._length !== null) {
 			return ready(this._length);
 		}
@@ -322,7 +322,7 @@ export default class IteratorBackedSequence implements ISequence {
 		this._currentPosition = to;
 	}
 
-	private tryIsEmpty(): AsyncResult<boolean> {
+	private tryIsEmpty(): IAsyncResult<boolean> {
 		if (this._length === 0) {
 			return ready(true);
 		}
@@ -333,7 +333,7 @@ export default class IteratorBackedSequence implements ISequence {
 		return ready(firstValue.value === null);
 	}
 
-	private tryIsSingleton(): AsyncResult<boolean> {
+	private tryIsSingleton(): IAsyncResult<boolean> {
 		if (this._length !== null) {
 			return ready(this._length === 1);
 		}

--- a/src/expressions/dataTypes/Sequences/SingletonSequence.ts
+++ b/src/expressions/dataTypes/Sequences/SingletonSequence.ts
@@ -1,5 +1,5 @@
 import ExecutionParameters from '../../ExecutionParameters';
-import { AsyncIterator, AsyncResult, DONE_TOKEN, ready } from '../../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IAsyncResult, ready } from '../../util/iterators';
 import atomize from '../atomize';
 import ISequence, { SwitchCasesCases } from '../ISequence';
 import sequenceFactory from '../sequenceFactory';
@@ -7,7 +7,7 @@ import Value from '../Value';
 import getEffectiveBooleanValue from './getEffectiveBooleanValue';
 
 export default class SingletonSequence implements ISequence {
-	public value: AsyncIterator<Value>;
+	public value: IAsyncIterator<Value>;
 
 	private _effectiveBooleanValue: boolean;
 
@@ -78,19 +78,19 @@ export default class SingletonSequence implements ISequence {
 		return cases.default(this);
 	}
 
-	public tryGetAllValues(): AsyncResult<Value[]> {
+	public tryGetAllValues(): IAsyncResult<Value[]> {
 		return ready(this.getAllValues());
 	}
 
-	public tryGetEffectiveBooleanValue(): AsyncResult<boolean> {
+	public tryGetEffectiveBooleanValue(): IAsyncResult<boolean> {
 		return ready(this.getEffectiveBooleanValue());
 	}
 
-	public tryGetFirst(): AsyncResult<Value> {
+	public tryGetFirst(): IAsyncResult<Value> {
 		return ready(this.first());
 	}
 
-	public tryGetLength(): AsyncResult<number> {
+	public tryGetLength(): IAsyncResult<number> {
 		return ready(1);
 	}
 }

--- a/src/expressions/dataTypes/atomize.ts
+++ b/src/expressions/dataTypes/atomize.ts
@@ -64,7 +64,7 @@ export default function atomize(
 
 		return createAtomicValue(
 			allTextNodes
-				.map((textNode) => {
+				.map(textNode => {
 					return executionParameters.domFacade.getData(textNode);
 				})
 				.join(''),

--- a/src/expressions/dataTypes/atomize.ts
+++ b/src/expressions/dataTypes/atomize.ts
@@ -52,19 +52,19 @@ export default function atomize(
 		// This is an element or a document node. Because we do not know the specific type of this element.
 		// Documents should always be an untypedAtomic, of elements, we do not know the type, so they are untypedAtomic too
 		const allTextNodes = [];
-		(function getTextNodes(node) {
-			if (node.nodeType === TEXT_NODE || node.nodeType === 4) {
-				allTextNodes.push(node);
+		(function getTextNodes(aNode) {
+			if (aNode.nodeType === TEXT_NODE || aNode.nodeType === 4) {
+				allTextNodes.push(aNode);
 				return;
 			}
-			executionParameters.domFacade.getChildNodes(node).forEach(function(childNode) {
+			executionParameters.domFacade.getChildNodes(aNode).forEach(function(childNode) {
 				getTextNodes(childNode);
 			});
 		})(node);
 
 		return createAtomicValue(
 			allTextNodes
-				.map(function(textNode) {
+				.map((textNode) => {
 					return executionParameters.domFacade.getData(textNode);
 				})
 				.join(''),

--- a/src/expressions/dataTypes/casting/castToBase64Binary.ts
+++ b/src/expressions/dataTypes/casting/castToBase64Binary.ts
@@ -4,11 +4,11 @@ import CastResult from './CastResult';
 const createBase64BinaryValue = value => createAtomicValue(value, 'xs:base64Binary');
 
 function hexToString(hex) {
-	let string = '';
+	let text = '';
 	for (let i = 0; i < hex.length; i += 2) {
-		string += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
+		text += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
 	}
-	return string;
+	return text;
 }
 
 declare var btoa;

--- a/src/expressions/dataTypes/casting/castToBase64Binary.ts
+++ b/src/expressions/dataTypes/casting/castToBase64Binary.ts
@@ -11,6 +11,8 @@ function hexToString(hex) {
 	return string;
 }
 
+declare var btoa;
+
 export default function castToBase64Binary(instanceOf: (string) => boolean): (Value) => CastResult {
 	if (instanceOf('xs:hexBinary')) {
 		return value => ({

--- a/src/expressions/dataTypes/casting/castToBase64Binary.ts
+++ b/src/expressions/dataTypes/casting/castToBase64Binary.ts
@@ -11,7 +11,8 @@ function hexToString(hex) {
 	return text;
 }
 
-declare var btoa;
+// This declaration is needed, as we don't depend anymore on lib.dom.
+declare var btoa: ((s: string) => string);
 
 export default function castToBase64Binary(instanceOf: (string) => boolean): (Value) => CastResult {
 	if (instanceOf('xs:hexBinary')) {
@@ -27,9 +28,9 @@ export default function castToBase64Binary(instanceOf: (string) => boolean): (Va
 		});
 	}
 	return () => ({
-		successful: false,
 		error: new Error(
 			'XPTY0004: Casting not supported from given type to xs:base64Binary or any of its derived types.'
-		)
+		),
+		successful: false
 	});
 }

--- a/src/expressions/dataTypes/casting/castToHexBinary.ts
+++ b/src/expressions/dataTypes/casting/castToHexBinary.ts
@@ -12,7 +12,8 @@ function stringToHex(string) {
 	return hex.toUpperCase();
 }
 
-declare var atob;
+// This declaration is needed, as we don't depend anymore on lib.dom.
+declare var atob: ((s: string) => string);
 
 export default function castToGDay(instanceOf: (string) => boolean): (Value) => CastResult {
 	if (instanceOf('xs:base64Binary')) {

--- a/src/expressions/dataTypes/casting/castToHexBinary.ts
+++ b/src/expressions/dataTypes/casting/castToHexBinary.ts
@@ -12,6 +12,8 @@ function stringToHex(string) {
 	return hex.toUpperCase();
 }
 
+declare var atob;
+
 export default function castToGDay(instanceOf: (string) => boolean): (Value) => CastResult {
 	if (instanceOf('xs:base64Binary')) {
 		return value => ({

--- a/src/expressions/dataTypes/sequenceFactory.ts
+++ b/src/expressions/dataTypes/sequenceFactory.ts
@@ -1,4 +1,4 @@
-import { AsyncIterator } from '../util/iterators';
+import { IAsyncIterator } from '../util/iterators';
 import { falseBoolean, trueBoolean } from './createAtomicValue';
 import ISequence from './ISequence';
 import ArrayBackedSequence from './Sequences/ArrayBackedSequence';
@@ -10,8 +10,8 @@ import Value from './Value';
 const emptySequence = new EmptySequence();
 
 function create(
-	value: Value | Value[] | AsyncIterator<Value> = null,
-	predictedLength: number = null
+	value: Value | Value[] | IAsyncIterator<Value> | null = null,
+	predictedLength: number | null | undefined = null
 ): ISequence {
 	if (value === null) {
 		return emptySequence;
@@ -27,10 +27,10 @@ function create(
 		}
 	}
 
-	if ((value as AsyncIterator<Value>).next) {
+	if ((value as IAsyncIterator<Value>).next) {
 		return new IteratorBackedSequence(
 			sequenceFactory,
-			value as AsyncIterator<Value>,
+			value as IAsyncIterator<Value>,
 			predictedLength
 		);
 	}

--- a/src/expressions/functions/builtInFunctions.arrays.ts
+++ b/src/expressions/functions/builtInFunctions.arrays.ts
@@ -236,7 +236,7 @@ const arrayFilter: FunctionDefinitionType = function(
 							effectiveBooleanValues.map(filterResult =>
 								filterResult.ready ? Promise.resolve() : filterResult.promise
 							)
-						)
+						).then(_ => undefined)
 					);
 				}
 				const newMembers = (array as ArrayValue).members.filter(

--- a/src/expressions/functions/builtInFunctions.fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions.fontoxpath.ts
@@ -111,7 +111,7 @@ const fontoxpathSleep: FunctionDefinitionType = (
 	howLong
 ) => {
 	let doneWithSleep = false;
-	let readyPromise: Promise<{}>;
+	let readyPromise: Promise<void>;
 
 	const valueIterator = val.value;
 	return sequenceFactory.create({

--- a/src/expressions/functions/builtInFunctions.fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions.fontoxpath.ts
@@ -151,7 +151,11 @@ const fontoxpathVersion: FunctionDefinitionType = () => {
 	return sequenceFactory.singleton(createAtomicValue(version, 'xs:string'));
 };
 
-const fontoxpathFetch: FunctionDefinitionType = (
+// TODO: implement a domparser instead of using the global one from the browser
+declare var DOMParser;
+declare var fetch;
+
+const fontoxpathFetch: FunctionDefinitionType = function(
 	_dynamicContext,
 	_executionParameters,
 	_staticContext,
@@ -169,6 +173,8 @@ const fontoxpathFetch: FunctionDefinitionType = (
 				if (!urlValue.ready) {
 					return urlValue;
 				}
+
+
 				readyPromise = fetch(urlValue.value.value)
 					.then(response => response.text())
 					.then(text => new DOMParser().parseFromString(text, 'application/xml'))

--- a/src/expressions/functions/builtInFunctions.fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions.fontoxpath.ts
@@ -170,7 +170,6 @@ const fontoxpathFetch: FunctionDefinitionType = (
 					return urlValue;
 				}
 
-
 				readyPromise = fetch(urlValue.value.value)
 					.then(response => response.text())
 					.then(text => new DOMParser().parseFromString(text, 'application/xml'))

--- a/src/expressions/functions/builtInFunctions.fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions.fontoxpath.ts
@@ -3,7 +3,7 @@ import createNodeValue from '../dataTypes/createNodeValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
 import DynamicContext from '../DynamicContext';
 import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
-import { AsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from '../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, notReady, ready } from '../util/iterators';
 
 import { FONTOXPATH_NAMESPACE_URI } from '../staticallyKnownNamespaces';
 
@@ -25,13 +25,8 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 	query,
 	args
 ) => {
-<<<<<<< HEAD
-	let resultIterator: AsyncIterator<Value>;
+	let resultIterator: IAsyncIterator<Value>;
 	let queryString: string;
-=======
-	let resultIterator;
-	let queryString;
->>>>>>> Fix tslint warnings
 	return sequenceFactory.create({
 		next: () => {
 			if (!resultIterator) {
@@ -217,11 +212,7 @@ export default {
 			callFunction: fontoxpathSleep,
 			localName: 'sleep',
 			namespaceURI: FONTOXPATH_NAMESPACE_URI,
-<<<<<<< HEAD
 			returnType: 'item()*'
-=======
-			returnType: 'item()*',
->>>>>>> Fix tslint warnings
 		},
 		{
 			argumentTypes: ['xs:string', 'map(*)'],

--- a/src/expressions/functions/builtInFunctions.fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions.fontoxpath.ts
@@ -25,8 +25,13 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 	query,
 	args
 ) => {
+<<<<<<< HEAD
 	let resultIterator: AsyncIterator<Value>;
 	let queryString: string;
+=======
+	let resultIterator;
+	let queryString;
+>>>>>>> Fix tslint warnings
 	return sequenceFactory.create({
 		next: () => {
 			if (!resultIterator) {
@@ -143,11 +148,7 @@ declare const VERSION: string | undefined;
 const fontoxpathVersion: FunctionDefinitionType = () => {
 	let version: string;
 	// TODO: Refactor when https://github.com/google/closure-compiler/issues/1601 is fixed
-	if (typeof VERSION === 'undefined') {
-		version = 'devbuild';
-	} else {
-		version = VERSION;
-	}
+	version = typeof VERSION === 'undefined' ? 'devbuild' : VERSION;
 	return sequenceFactory.singleton(createAtomicValue(version, 'xs:string'));
 };
 
@@ -155,7 +156,7 @@ const fontoxpathVersion: FunctionDefinitionType = () => {
 declare var DOMParser;
 declare var fetch;
 
-const fontoxpathFetch: FunctionDefinitionType = function(
+const fontoxpathFetch: FunctionDefinitionType = (
 	_dynamicContext,
 	_executionParameters,
 	_staticContext,
@@ -216,7 +217,11 @@ export default {
 			callFunction: fontoxpathSleep,
 			localName: 'sleep',
 			namespaceURI: FONTOXPATH_NAMESPACE_URI,
+<<<<<<< HEAD
 			returnType: 'item()*'
+=======
+			returnType: 'item()*',
+>>>>>>> Fix tslint warnings
 		},
 		{
 			argumentTypes: ['xs:string', 'map(*)'],

--- a/src/expressions/functions/builtInFunctions.sequences.deepEqual.ts
+++ b/src/expressions/functions/builtInFunctions.sequences.deepEqual.ts
@@ -8,6 +8,7 @@ import createSingleValueIterator from '../util/createSingleValueIterator';
 import builtInFunctionsNode from './builtInFunctions.node';
 
 import { equal } from '../dataTypes/valueTypes/DateTime';
+<<<<<<< HEAD
 import {
 	AsyncIterator,
 	DONE_TOKEN,
@@ -16,6 +17,9 @@ import {
 	notReady,
 	ready
 } from '../util/iterators';
+=======
+import { IAsyncIterator, DONE_TOKEN, notReady, ready } from '../util/iterators';
+>>>>>>> Start on fixing tests
 
 import ArrayValue from '../dataTypes/ArrayValue';
 import MapValue from '../dataTypes/MapValue';
@@ -28,8 +32,8 @@ const nodeName = builtInFunctionsNode.functions.nodeName;
 
 function asyncGenerateEvery<T>(
 	items: T[],
-	callback: (item: T, index: number, all: T[]) => AsyncIterator<boolean>
-): AsyncIterator<boolean> {
+	callback: (item: T, index: number, all: T[]) => IAsyncIterator<boolean>
+): IAsyncIterator<boolean> {
 	let i = 0;
 	const l = items.length;
 	let done = false;
@@ -128,7 +132,7 @@ function sequenceDeepEqual(
 	staticContext: StaticContext,
 	sequence1: ISequence,
 	sequence2: ISequence
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	const it1 = sequence1.value;
 	const it2 = sequence2.value;
 	let item1: IterationResult<Value> = null;
@@ -193,7 +197,7 @@ function mapTypeDeepEqual(
 	staticContext: StaticContext,
 	item1: MapValue,
 	item2: MapValue
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	if (item1.keyValuePairs.length !== item2.keyValuePairs.length) {
 		return createSingleValueIterator(false);
 	}
@@ -229,7 +233,7 @@ function arrayTypeDeepEqual(
 	staticContext: StaticContext,
 	item1: ArrayValue,
 	item2: ArrayValue
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	if (item1.members.length !== item2.members.length) {
 		return createSingleValueIterator(false);
 	}
@@ -252,7 +256,7 @@ function nodeDeepEqual(
 	staticContext: StaticContext,
 	item1: Value,
 	item2: Value
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	let item1Nodes = executionParameters.domFacade.getChildNodes(item1.value);
 	let item2Nodes = executionParameters.domFacade.getChildNodes(item2.value);
 
@@ -277,7 +281,7 @@ function elementNodeDeepEqual(
 	staticContext: StaticContext,
 	item1: Value,
 	item2: Value
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	const namesAreEqualResultGenerator = sequenceDeepEqual(
 		dynamicContext,
 		executionParameters,
@@ -361,7 +365,7 @@ function atomicTypeNodeDeepEqual(
 	staticContext: StaticContext,
 	item1: Value,
 	item2: Value
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	const namesAreEqualResultGenerator = sequenceDeepEqual(
 		dynamicContext,
 		executionParameters,
@@ -414,7 +418,7 @@ function itemDeepEqual(
 	staticContext: StaticContext,
 	item1: Value,
 	item2: Value
-): AsyncIterator<boolean> {
+): IAsyncIterator<boolean> {
 	// All atomic types
 	if (
 		isSubtypeOf(item1.type, 'xs:anyAtomicType') &&

--- a/src/expressions/functions/builtInFunctions.sequences.deepEqual.ts
+++ b/src/expressions/functions/builtInFunctions.sequences.deepEqual.ts
@@ -8,18 +8,14 @@ import createSingleValueIterator from '../util/createSingleValueIterator';
 import builtInFunctionsNode from './builtInFunctions.node';
 
 import { equal } from '../dataTypes/valueTypes/DateTime';
-<<<<<<< HEAD
 import {
-	AsyncIterator,
 	DONE_TOKEN,
+	IAsyncIterator,
 	IterationHint,
 	IterationResult,
 	notReady,
 	ready
 } from '../util/iterators';
-=======
-import { IAsyncIterator, DONE_TOKEN, notReady, ready } from '../util/iterators';
->>>>>>> Start on fixing tests
 
 import ArrayValue from '../dataTypes/ArrayValue';
 import MapValue from '../dataTypes/MapValue';
@@ -37,7 +33,7 @@ function asyncGenerateEvery<T>(
 	let i = 0;
 	const l = items.length;
 	let done = false;
-	let filterGenerator: AsyncIterator<boolean> = null;
+	let filterGenerator: IAsyncIterator<boolean> = null;
 	return {
 		next: () => {
 			if (!done) {
@@ -137,7 +133,7 @@ function sequenceDeepEqual(
 	const it2 = sequence2.value;
 	let item1: IterationResult<Value> = null;
 	let item2: IterationResult<Value> = null;
-	let comparisonGenerator: AsyncIterator<boolean> = null;
+	let comparisonGenerator: IAsyncIterator<boolean> = null;
 	let done: boolean;
 	return {
 		next: (_hint: IterationHint) => {

--- a/src/expressions/functions/builtInFunctions.sequences.ts
+++ b/src/expressions/functions/builtInFunctions.sequences.ts
@@ -8,7 +8,7 @@ import TypeDeclaration from '../dataTypes/TypeDeclaration';
 import { getPrimitiveTypeName } from '../dataTypes/typeHelpers';
 import Value from '../dataTypes/Value';
 import { FUNCTIONS_NAMESPACE_URI } from '../staticallyKnownNamespaces';
-import { AsyncIterator, DONE_TOKEN, IterationHint, notReady, ready } from '../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, notReady, ready } from '../util/iterators';
 import zipSingleton from '../util/zipSingleton';
 import { transformArgument } from './argumentHelper';
 import sequenceDeepEqual from './builtInFunctions.sequences.deepEqual';
@@ -572,7 +572,7 @@ const fnForEach: FunctionDefinitionType = (
 	}
 
 	const outerIterator = sequence.value;
-	let innerIterator: AsyncIterator<Value>;
+	let innerIterator: IAsyncIterator<Value>;
 	return sequenceFactory.create({
 		next: (hint: IterationHint) => {
 			while (true) {

--- a/src/expressions/path/PathExpression.ts
+++ b/src/expressions/path/PathExpression.ts
@@ -250,11 +250,11 @@ class PathExpression extends Expression {
 						intermediateResultNodesSequence
 					);
 				}
-				let resultValuesInOrderOfEvaluation = {
+				let resultValuesInOrderOfEvaluation: IAsyncIterator<ISequence> = {
 					next: (hint: IterationHint) => {
 						const childContext = childContextIterator.next(hint);
 						if (!childContext.ready) {
-							return childContext;
+							return notReady(childContext.promise);
 						}
 
 						if (childContext.done) {
@@ -286,15 +286,15 @@ class PathExpression extends Expression {
 							const resultValuesInReverseOrder = resultValuesInOrderOfEvaluation;
 							resultValuesInOrderOfEvaluation = {
 								next: (hint: IterationHint) => {
-									const result = resultValuesInReverseOrder.next(hint);
-									if (!result.ready) {
-										return result;
+									const res = resultValuesInReverseOrder.next(hint);
+									if (!res.ready) {
+										return res;
 									}
-									if (result.done) {
-										return result;
+									if (res.done) {
+										return res;
 									}
 									return ready(
-										result.value.mapAll(items =>
+										res.value.mapAll(items =>
 											sequenceFactory.create(items.reverse())
 										)
 									);

--- a/src/expressions/path/PathExpression.ts
+++ b/src/expressions/path/PathExpression.ts
@@ -10,18 +10,14 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Specificity from '../Specificity';
 import createSingleValueIterator from '../util/createSingleValueIterator';
-<<<<<<< HEAD
 import {
-	AsyncIterator,
 	DONE_TOKEN,
+	IAsyncIterator,
 	IterationHint,
 	IterationResult,
 	notReady,
 	ready
 } from '../util/iterators';
-=======
-import { DONE_TOKEN, IAsyncIterator, notReady, ready } from '../util/iterators';
->>>>>>> Start on fixing tests
 
 function isSameNodeValue(a: Value, b: Value) {
 	if (a === null || b === null) {
@@ -34,17 +30,12 @@ function isSameNodeValue(a: Value, b: Value) {
 	return a.value === b.value;
 }
 
-<<<<<<< HEAD
-function concatSortedSequences(sequences: AsyncIterator<ISequence>): ISequence {
+function concatSortedSequences(sequences: IAsyncIterator<ISequence>): ISequence {
 	let currentSequence = sequences.next(IterationHint.NONE);
-=======
-function concatSortedSequences(_, sequences: IAsyncIterator<ISequence>): ISequence {
-	let currentSequence = sequences.next();
->>>>>>> Start on fixing tests
 	if (currentSequence.done) {
 		return sequenceFactory.empty();
 	}
-	let currentIterator: AsyncIterator<Value> = null;
+	let currentIterator: IAsyncIterator<Value> = null;
 	let previousValue: Value = null;
 	return sequenceFactory.create({
 		next(hint: IterationHint) {
@@ -83,18 +74,13 @@ function concatSortedSequences(_, sequences: IAsyncIterator<ISequence>): ISequen
 	});
 }
 
-interface IMappedIterator extends AsyncIterator<Value> {
+interface IMappedIterator extends IAsyncIterator<Value> {
 	current: IterationResult<Value>;
 }
 
 function mergeSortedSequences(
-<<<<<<< HEAD
 	domFacade: IWrappingDomFacade,
-	sequences: AsyncIterator<ISequence>
-=======
-	domFacade: DomFacade,
 	sequences: IAsyncIterator<ISequence>
->>>>>>> Start on fixing tests
 ): ISequence {
 	const allIterators: IMappedIterator[] = [];
 	// Because the sequences are sorted locally, but unsorted globally, we first need to sort all the iterators.
@@ -202,17 +188,10 @@ function mergeSortedSequences(
 	});
 }
 
-<<<<<<< HEAD
 function sortResults(domFacade: IWrappingDomFacade, result: Value[]) {
 	let resultContainsNodes = false;
 	let resultContainsNonNodes = false;
 	result.forEach(resultValue => {
-=======
-function sortResults(domFacade, result) {
-	let resultContainsNodes = false;
-	let resultContainsNonNodes = false;
-	result.forEach((resultValue) => {
->>>>>>> Start on fixing tests
 		if (isSubtypeOf(resultValue.type, 'node()')) {
 			resultContainsNodes = true;
 		} else {
@@ -250,11 +229,7 @@ class PathExpression extends Expression {
 				resultOrder: requireSortedResults
 					? RESULT_ORDERINGS.SORTED
 					: RESULT_ORDERINGS.UNSORTED,
-<<<<<<< HEAD
 				subtree: pathResultsInSubtreeSequence
-=======
-				subtree: pathResultsInSubtreeSequence,
->>>>>>> Start on fixing tests
 			}
 		);
 
@@ -266,7 +241,7 @@ class PathExpression extends Expression {
 		let sequenceHasPeerProperty = true;
 		const result = this._stepExpressions.reduce<ISequence>(
 			(intermediateResultNodesSequence, selector) => {
-				let childContextIterator: AsyncIterator<DynamicContext>;
+				let childContextIterator: IAsyncIterator<DynamicContext>;
 				if (intermediateResultNodesSequence === null) {
 					// first call, we should use the current dynamic context
 					childContextIterator = createSingleValueIterator(dynamicContext);

--- a/src/expressions/path/PathExpression.ts
+++ b/src/expressions/path/PathExpression.ts
@@ -10,6 +10,7 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Specificity from '../Specificity';
 import createSingleValueIterator from '../util/createSingleValueIterator';
+<<<<<<< HEAD
 import {
 	AsyncIterator,
 	DONE_TOKEN,
@@ -18,6 +19,9 @@ import {
 	notReady,
 	ready
 } from '../util/iterators';
+=======
+import { DONE_TOKEN, IAsyncIterator, notReady, ready } from '../util/iterators';
+>>>>>>> Start on fixing tests
 
 function isSameNodeValue(a: Value, b: Value) {
 	if (a === null || b === null) {
@@ -30,8 +34,13 @@ function isSameNodeValue(a: Value, b: Value) {
 	return a.value === b.value;
 }
 
+<<<<<<< HEAD
 function concatSortedSequences(sequences: AsyncIterator<ISequence>): ISequence {
 	let currentSequence = sequences.next(IterationHint.NONE);
+=======
+function concatSortedSequences(_, sequences: IAsyncIterator<ISequence>): ISequence {
+	let currentSequence = sequences.next();
+>>>>>>> Start on fixing tests
 	if (currentSequence.done) {
 		return sequenceFactory.empty();
 	}
@@ -79,8 +88,13 @@ interface IMappedIterator extends AsyncIterator<Value> {
 }
 
 function mergeSortedSequences(
+<<<<<<< HEAD
 	domFacade: IWrappingDomFacade,
 	sequences: AsyncIterator<ISequence>
+=======
+	domFacade: DomFacade,
+	sequences: IAsyncIterator<ISequence>
+>>>>>>> Start on fixing tests
 ): ISequence {
 	const allIterators: IMappedIterator[] = [];
 	// Because the sequences are sorted locally, but unsorted globally, we first need to sort all the iterators.
@@ -188,10 +202,17 @@ function mergeSortedSequences(
 	});
 }
 
+<<<<<<< HEAD
 function sortResults(domFacade: IWrappingDomFacade, result: Value[]) {
 	let resultContainsNodes = false;
 	let resultContainsNonNodes = false;
 	result.forEach(resultValue => {
+=======
+function sortResults(domFacade, result) {
+	let resultContainsNodes = false;
+	let resultContainsNonNodes = false;
+	result.forEach((resultValue) => {
+>>>>>>> Start on fixing tests
 		if (isSubtypeOf(resultValue.type, 'node()')) {
 			resultContainsNodes = true;
 		} else {
@@ -229,7 +250,11 @@ class PathExpression extends Expression {
 				resultOrder: requireSortedResults
 					? RESULT_ORDERINGS.SORTED
 					: RESULT_ORDERINGS.UNSORTED,
+<<<<<<< HEAD
 				subtree: pathResultsInSubtreeSequence
+=======
+				subtree: pathResultsInSubtreeSequence,
+>>>>>>> Start on fixing tests
 			}
 		);
 

--- a/src/expressions/staticallyKnownNamespaces.ts
+++ b/src/expressions/staticallyKnownNamespaces.ts
@@ -7,7 +7,7 @@ export const MAP_NAMESPACE_URI = 'http://www.w3.org/2005/xpath-functions/map';
 export const MATH_NAMESPACE_URI = 'http://www.w3.org/2005/xpath-functions/math';
 export const FONTOXPATH_NAMESPACE_URI = 'http://fontoxml.com/fontoxpath';
 
-export const staticallyKnownNamespaceByPrefix = {
+export const staticallyKnownNamespaceByPrefix: {[prefix: string]: string} = {
 	['xml']: XML_NAMESPACE_URI,
 	['xs']: XMLSCHEMA_NAMESPACE_URI,
 	['fn']: FUNCTIONS_NAMESPACE_URI,

--- a/src/expressions/staticallyKnownNamespaces.ts
+++ b/src/expressions/staticallyKnownNamespaces.ts
@@ -7,7 +7,7 @@ export const MAP_NAMESPACE_URI = 'http://www.w3.org/2005/xpath-functions/map';
 export const MATH_NAMESPACE_URI = 'http://www.w3.org/2005/xpath-functions/math';
 export const FONTOXPATH_NAMESPACE_URI = 'http://fontoxml.com/fontoxpath';
 
-export const staticallyKnownNamespaceByPrefix: {[prefix: string]: string} = {
+export const staticallyKnownNamespaceByPrefix: { [prefix: string]: string } = {
 	['xml']: XML_NAMESPACE_URI,
 	['xs']: XMLSCHEMA_NAMESPACE_URI,
 	['fn']: FUNCTIONS_NAMESPACE_URI,

--- a/src/expressions/util/createChildGenerator.ts
+++ b/src/expressions/util/createChildGenerator.ts
@@ -1,11 +1,11 @@
 import { ConcreteChildNode, ConcreteNode, NODE_TYPES } from '../../domFacade/ConcreteNode';
 import IDomFacade from '../../domFacade/IDomFacade';
-import { DONE_TOKEN, ready } from './iterators';
+import { DONE_TOKEN, IAsyncIterator, ready } from './iterators';
 
 export default function createChildGenerator(
 	domFacade: IDomFacade,
 	node: ConcreteNode
-): Iterator<ConcreteChildNode> {
+): IAsyncIterator<ConcreteChildNode> {
 	if (node.nodeType !== NODE_TYPES.ELEMENT_NODE && node.nodeType !== NODE_TYPES.DOCUMENT_NODE) {
 		return {
 			next: () => {

--- a/src/expressions/util/createDescendantGenerator.ts
+++ b/src/expressions/util/createDescendantGenerator.ts
@@ -1,13 +1,13 @@
 import {
-	ConcreteParentNode,
-	NODE_TYPES,
+	ConcreteChildNode,
 	ConcreteNode,
-	ConcreteChildNode
+	ConcreteParentNode,
+	NODE_TYPES
 } from '../../domFacade/ConcreteNode';
 import IWrappingDomFacade from '../../domFacade/IWrappingDomFacade';
 import createNodeValue from '../dataTypes/createNodeValue';
 import createChildGenerator from './createChildGenerator';
-import { DONE_TOKEN, ready } from './iterators';
+import { DONE_TOKEN, IterationHint, ready } from './iterators';
 
 function findDeepestLastDescendant(
 	node: ConcreteNode,
@@ -81,13 +81,13 @@ export default function createDescendantGenerator(
 			if (!descendantIteratorStack.length) {
 				return DONE_TOKEN;
 			}
-			let value = descendantIteratorStack[0].next();
+			let value = descendantIteratorStack[0].next(IterationHint.NONE);
 			while (value.done) {
 				descendantIteratorStack.shift();
 				if (!descendantIteratorStack.length) {
 					return DONE_TOKEN;
 				}
-				value = descendantIteratorStack[0].next();
+				value = descendantIteratorStack[0].next(IterationHint.NONE);
 			}
 			// Iterator over these children next
 			descendantIteratorStack.unshift(createChildGenerator(domFacade, value.value));

--- a/src/expressions/util/createDoublyIterableSequence.ts
+++ b/src/expressions/util/createDoublyIterableSequence.ts
@@ -1,9 +1,10 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import { IterationHint } from './iterators';
+import Value from '../dataTypes/Value';
+import { IterationHint, IterationResult } from './iterators';
 
 export default function createDoublyIterableSequence(sequence: ISequence): () => ISequence {
-	const savedValues = [];
+	const savedValues: IterationResult<Value>[] = [];
 	const backingIterator = sequence.value;
 	return () => {
 		let i = 0;

--- a/src/expressions/util/createSingleValueIterator.ts
+++ b/src/expressions/util/createSingleValueIterator.ts
@@ -1,6 +1,6 @@
-import { AsyncIterator, DONE_TOKEN, ready } from './iterators';
+import { DONE_TOKEN, IAsyncIterator, ready } from './iterators';
 
-export default function createSingleValueIterator<T>(onlyValue: T): AsyncIterator<T> {
+export default function createSingleValueIterator<T>(onlyValue: T): IAsyncIterator<T> {
 	let hasPassed = false;
 	return {
 		next: () => {

--- a/src/expressions/util/iterators.ts
+++ b/src/expressions/util/iterators.ts
@@ -29,7 +29,7 @@ export function ready<T>(value: T) {
 }
 
 export interface IAsyncIterator<T> {
-	next(): IterationResult<T>;
+	next(hint: IterationHint): IterationResult<T>;
 }
 
 export interface IAsyncResult<T> {

--- a/src/expressions/util/iterators.ts
+++ b/src/expressions/util/iterators.ts
@@ -2,17 +2,17 @@ export class IterationResult<T> {
 	public done: boolean;
 	public promise: Promise<void> | undefined;
 	public ready: boolean;
-	public value: T | undefined;
+	public value: T | undefined | null;
 	constructor(
 		done: boolean,
 		value: T | undefined,
 		promise: Promise<void> | undefined,
-		ready: boolean
+		isReady: boolean
 	) {
 		this.done = done;
 		this.value = value;
 		this.promise = promise;
-		this.ready = ready;
+		this.ready = isReady;
 	}
 }
 
@@ -22,14 +22,17 @@ export enum IterationHint {
 }
 
 export const DONE_TOKEN = new IterationResult(true, undefined, undefined, true);
-export const notReady = promise => new IterationResult(false, undefined, promise, false);
-export const ready = value => new IterationResult(false, value, undefined, true);
-
-export interface AsyncIterator<T> {
-	next(hint: IterationHint): IterationResult<T>;
+export const notReady = (promise: Promise<void> | undefined) =>
+	new IterationResult(false, undefined, promise, false);
+export function ready<T>(value: T) {
+	return new IterationResult(false, value, undefined, true);
 }
 
-export interface AsyncResult<T> {
+export interface IAsyncIterator<T> {
+	next(): IterationResult<T>;
+}
+
+export interface IAsyncResult<T> {
 	promise: Promise<void> | undefined;
 	ready: boolean;
 	value: T | undefined;

--- a/src/expressions/util/zipSingleton.ts
+++ b/src/expressions/util/zipSingleton.ts
@@ -1,6 +1,6 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import { AsyncIterator, IterationHint, notReady } from './iterators';
+import { IAsyncIterator, IterationHint, notReady } from './iterators';
 
 import Value from '../dataTypes/Value';
 
@@ -13,7 +13,7 @@ export default function zipSingleton(sequences: ISequence[], callback: CallbackT
 		return callback(firstValues.map(seq => seq.value));
 	}
 
-	let iterator: AsyncIterator<Value> = null;
+	let iterator: IAsyncIterator<Value> = null;
 	return sequenceFactory.create({
 		next: (hint: IterationHint) => {
 			if (iterator === null) {

--- a/src/expressions/xquery-update/DeleteExpression.ts
+++ b/src/expressions/xquery-update/DeleteExpression.ts
@@ -7,7 +7,7 @@ import { deletePu } from './pulPrimitives';
 import { mergeUpdates } from './pulRoutines';
 
 import isSubTypeOf from '../dataTypes/isSubtypeOf';
-import { AsyncIterator, IterationHint, ready } from '../util/iterators';
+import { IAsyncIterator, IterationHint, ready } from '../util/iterators';
 
 import Value from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
@@ -31,8 +31,8 @@ class DeleteExpression extends UpdatingExpression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
-		const targetValueIterator: AsyncIterator<
+	): IAsyncIterator<UpdatingExpressionResult> {
+		const targetValueIterator: IAsyncIterator<
 			UpdatingExpressionResult
 		> = super.ensureUpdateListWrapper(this._targetExpression)(
 			dynamicContext,

--- a/src/expressions/xquery-update/InsertExpression.ts
+++ b/src/expressions/xquery-update/InsertExpression.ts
@@ -14,7 +14,7 @@ import {
 import { mergeUpdates } from './pulRoutines';
 
 import isSubTypeOf from '../dataTypes/isSubtypeOf';
-import { AsyncIterator, IterationHint, ready } from '../util/iterators';
+import { IAsyncIterator, IterationHint, ready } from '../util/iterators';
 import parseContent from '../xquery/ElementConstructorContent';
 
 import DynamicContext from '../DynamicContext';
@@ -127,7 +127,7 @@ class InsertExpression extends UpdatingExpression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
+	): IAsyncIterator<UpdatingExpressionResult> {
 		const sourceValueIterator = super.ensureUpdateListWrapper(this._sourceExpression)(
 			dynamicContext,
 			executionParameters

--- a/src/expressions/xquery-update/RenameExpression.ts
+++ b/src/expressions/xquery-update/RenameExpression.ts
@@ -8,7 +8,7 @@ import { mergeUpdates } from './pulRoutines';
 
 import isSubTypeOf from '../dataTypes/isSubtypeOf';
 import QName from '../dataTypes/valueTypes/QName';
-import { AsyncIterator, IterationHint, ready } from '../util/iterators';
+import { IAsyncIterator, IterationHint, ready } from '../util/iterators';
 import { evaluateNCNameExpression, evaluateQNameExpression } from '../xquery/nameExpression';
 
 import sequenceFactory from '../dataTypes/sequenceFactory';
@@ -112,7 +112,7 @@ class RenameExpression extends UpdatingExpression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
+	): IAsyncIterator<UpdatingExpressionResult> {
 		const targetValueIterator = super.ensureUpdateListWrapper(this._targetExpression)(
 			dynamicContext,
 			executionParameters

--- a/src/expressions/xquery-update/ReplaceExpression.ts
+++ b/src/expressions/xquery-update/ReplaceExpression.ts
@@ -9,7 +9,7 @@ import { mergeUpdates } from './pulRoutines';
 import atomize from '../dataTypes/atomize';
 import castToType from '../dataTypes/castToType';
 import isSubTypeOf from '../dataTypes/isSubtypeOf';
-import { AsyncIterator, DONE_TOKEN, IterationHint, ready } from '../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, ready } from '../util/iterators';
 import parseContent from '../xquery/ElementConstructorContent';
 
 import { errXQDY0026, errXQDY0072 } from '../xquery/XQueryErrors';
@@ -29,8 +29,8 @@ import {
 
 function evaluateReplaceNode(
 	executionParameters: ExecutionParameters,
-	targetValueIterator: AsyncIterator<UpdatingExpressionResult>,
-	replacementValueIterator: AsyncIterator<UpdatingExpressionResult>
+	targetValueIterator: IAsyncIterator<UpdatingExpressionResult>,
+	replacementValueIterator: IAsyncIterator<UpdatingExpressionResult>
 ) {
 	let rlist;
 	let rlistUpdates;
@@ -161,8 +161,8 @@ function evaluateReplaceNode(
 
 function evaluateReplaceNodeValue(
 	executionParameters: ExecutionParameters,
-	targetValueIterator: AsyncIterator<UpdatingExpressionResult>,
-	replacementValueIterator: AsyncIterator<UpdatingExpressionResult>
+	targetValueIterator: IAsyncIterator<UpdatingExpressionResult>,
+	replacementValueIterator: IAsyncIterator<UpdatingExpressionResult>
 ) {
 	let target;
 	let targetUpdates;
@@ -325,7 +325,7 @@ class ReplaceExpression extends UpdatingExpression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
+	): IAsyncIterator<UpdatingExpressionResult> {
 		const targetValueIterator = super.ensureUpdateListWrapper(this._targetExpression)(
 			dynamicContext,
 			executionParameters

--- a/src/expressions/xquery-update/TransformExpression.ts
+++ b/src/expressions/xquery-update/TransformExpression.ts
@@ -17,7 +17,7 @@ import Expression, { RESULT_ORDERINGS } from '../Expression';
 import Specificity from '../Specificity';
 import StaticContext from '../StaticContext';
 import UpdatingExpressionResult from '../UpdatingExpressionResult';
-import { AsyncIterator, IterationHint, ready } from '../util/iterators';
+import { IAsyncIterator, IterationHint, ready } from '../util/iterators';
 import { applyUpdates, mergeUpdates } from './pulRoutines';
 import UpdatingExpression from './UpdatingExpression';
 import { errXUDY0014, errXUDY0037, errXUTY0013 } from './XQueryUpdateFacilityErrors';
@@ -120,12 +120,12 @@ class TransformExpression extends UpdatingExpression {
 	public evaluateWithUpdateList(
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult> {
+	): IAsyncIterator<UpdatingExpressionResult> {
 		const { domFacade, nodesFactory, documentWriter } = executionParameters;
 
-		const sourceValueIterators: AsyncIterator<UpdatingExpressionResult>[] = [];
-		let modifyValueIterator: AsyncIterator<UpdatingExpressionResult>;
-		let returnValueIterator: AsyncIterator<UpdatingExpressionResult>;
+		const sourceValueIterators: IAsyncIterator<UpdatingExpressionResult>[] = [];
+		let modifyValueIterator: IAsyncIterator<UpdatingExpressionResult>;
+		let returnValueIterator: IAsyncIterator<UpdatingExpressionResult>;
 
 		let modifyPul;
 		const createdNodes = [];
@@ -137,7 +137,7 @@ class TransformExpression extends UpdatingExpression {
 					// The copy clause contains one or more variable bindings, each of which consists of a variable name and an expression called the source expression.
 					for (let i = createdNodes.length; i < this._variableBindings.length; i++) {
 						const variableBinding = this._variableBindings[i];
-						let sourceValueIterator: AsyncIterator<UpdatingExpressionResult> =
+						let sourceValueIterator: IAsyncIterator<UpdatingExpressionResult> =
 							sourceValueIterators[i];
 
 						// Each variable binding is processed as follows:

--- a/src/expressions/xquery-update/UpdatingExpression.ts
+++ b/src/expressions/xquery-update/UpdatingExpression.ts
@@ -3,7 +3,7 @@ import ExecutionParameters from '../ExecutionParameters';
 import Expression, { OptimizationOptions } from '../Expression';
 import Specificity from '../Specificity';
 import UpdatingExpressionResult from '../UpdatingExpressionResult';
-import { AsyncIterator, notReady, ready } from '../util/iterators';
+import { IAsyncIterator, notReady, ready } from '../util/iterators';
 
 abstract class UpdatingExpression extends Expression {
 	constructor(
@@ -21,7 +21,7 @@ abstract class UpdatingExpression extends Expression {
 	): (
 		dynamicContext: DynamicContext,
 		executionParameters: ExecutionParameters
-	) => AsyncIterator<UpdatingExpressionResult> {
+	) => IAsyncIterator<UpdatingExpressionResult> {
 		if (expression.isUpdating) {
 			const updatingExpression = expression as UpdatingExpression;
 			return (dynamicContext: DynamicContext, executionParameters: ExecutionParameters) =>
@@ -54,7 +54,7 @@ abstract class UpdatingExpression extends Expression {
 	public abstract evaluateWithUpdateList(
 		_dynamicContext: DynamicContext | null,
 		_executionParameters: ExecutionParameters
-	): AsyncIterator<UpdatingExpressionResult>;
+	): IAsyncIterator<UpdatingExpressionResult>;
 }
 
 export default UpdatingExpression;

--- a/src/expressions/xquery-update/applyPulPrimitives.ts
+++ b/src/expressions/xquery-update/applyPulPrimitives.ts
@@ -9,9 +9,9 @@ import {
 import IDomFacade from '../../domFacade/IDomFacade';
 import DomBackedNodesFactory from '../../nodesFactory/DomBackedNodesFactory';
 import INodesFactory from '../../nodesFactory/INodesFactory';
+import { Attr, Document, Element, Node, ProcessingInstruction } from '../../types/Types';
 import QName from '../dataTypes/valueTypes/QName';
 import { errXUDY0021 } from './XQueryUpdateFacilityErrors';
-import { Attr, Element, Document, Node, ProcessingInstruction } from '../../types/Types';
 
 /**
  * Deletes $target.

--- a/src/expressions/xquery-update/applyPulPrimitives.ts
+++ b/src/expressions/xquery-update/applyPulPrimitives.ts
@@ -11,12 +11,7 @@ import DomBackedNodesFactory from '../../nodesFactory/DomBackedNodesFactory';
 import INodesFactory from '../../nodesFactory/INodesFactory';
 import QName from '../dataTypes/valueTypes/QName';
 import { errXUDY0021 } from './XQueryUpdateFacilityErrors';
-
-const ELEMENT_NODE = 1;
-const ATTRIBUTE_NODE = 2;
-const TEXT_NODE = 3;
-const PROCESSING_INSTRUCTION_NODE = 7;
-const COMMENT_NODE = 8;
+import { Attr, Element, Document, Node, ProcessingInstruction } from '../../types/Types';
 
 /**
  * Deletes $target.
@@ -268,9 +263,9 @@ export const replaceNode = (
 	// The parent must exist or an error has been raised.
 	const parent = domFacade.getParentNode(target);
 
-	if (target.nodeType === ATTRIBUTE_NODE) {
+	if (target.nodeType === NODE_TYPES.ATTRIBUTE_NODE) {
 		// All replacement must consist of attribute nodes.
-		if (replacement.some(candidate => candidate.nodeType !== ATTRIBUTE_NODE)) {
+		if (replacement.some(candidate => candidate.nodeType !== NODE_TYPES.ATTRIBUTE_NODE)) {
 			throw new Error(
 				'Constraint "If $target is an attribute node, $replacement must consist of zero or more attribute nodes." failed.'
 			);
@@ -310,22 +305,22 @@ export const replaceNode = (
  * @param  documentWriter  The documentWriter for writing changes.
  */
 export const replaceValue = (
-	target: Element | Attr,
+	target: ConcreteElementNode | ConcreteAttributeNode,
 	stringValue: string,
 	domFacade: (IDomFacade | null) | undefined,
 	documentWriter: (IDocumentWriter | null) | undefined
 ) => {
-	if (target.nodeType === ATTRIBUTE_NODE) {
-		const element = domFacade.getParentNode(target as Attr) as Element;
+	if (target.nodeType === NODE_TYPES.ATTRIBUTE_NODE) {
+		const element = domFacade.getParentNode(target) as Element;
 		if (element) {
 			documentWriter.setAttributeNS(
 				element,
 				target.namespaceURI,
-				(target as Attr).name,
+				target.name,
 				stringValue
 			);
 		} else {
-			(target as Attr).value = stringValue;
+			target.value = stringValue;
 		}
 	} else {
 		documentWriter.setData(target, stringValue);

--- a/src/expressions/xquery-update/applyPulPrimitives.ts
+++ b/src/expressions/xquery-update/applyPulPrimitives.ts
@@ -313,12 +313,7 @@ export const replaceValue = (
 	if (target.nodeType === NODE_TYPES.ATTRIBUTE_NODE) {
 		const element = domFacade.getParentNode(target) as Element;
 		if (element) {
-			documentWriter.setAttributeNS(
-				element,
-				target.namespaceURI,
-				target.name,
-				stringValue
-			);
+			documentWriter.setAttributeNS(element, target.namespaceURI, target.name, stringValue);
 		} else {
 			target.value = stringValue;
 		}

--- a/src/expressions/xquery-update/pendingUpdates/InsertAttributesPendingUpdate.ts
+++ b/src/expressions/xquery-update/pendingUpdates/InsertAttributesPendingUpdate.ts
@@ -1,5 +1,7 @@
 import { ConcreteNode } from '../../../domFacade/ConcreteNode';
 import { IPendingUpdate } from '../IPendingUpdate';
+import { Attr } from '../../../types/Types';
+
 export class InsertAttributesPendingUpdate extends IPendingUpdate {
 	public readonly type: 'insertAttributes';
 	constructor(readonly target: ConcreteNode, readonly content: Attr[]) {

--- a/src/expressions/xquery-update/pendingUpdates/InsertAttributesPendingUpdate.ts
+++ b/src/expressions/xquery-update/pendingUpdates/InsertAttributesPendingUpdate.ts
@@ -1,6 +1,6 @@
 import { ConcreteNode } from '../../../domFacade/ConcreteNode';
-import { IPendingUpdate } from '../IPendingUpdate';
 import { Attr } from '../../../types/Types';
+import { IPendingUpdate } from '../IPendingUpdate';
 
 export class InsertAttributesPendingUpdate extends IPendingUpdate {
 	public readonly type: 'insertAttributes';

--- a/src/expressions/xquery-update/pendingUpdates/ReplaceElementContentPendingUpdate.ts
+++ b/src/expressions/xquery-update/pendingUpdates/ReplaceElementContentPendingUpdate.ts
@@ -1,5 +1,7 @@
 import { ConcreteNode } from '../../../domFacade/ConcreteNode';
 import { IPendingUpdate } from '../IPendingUpdate';
+import { Text } from '../../../types/Types';
+
 export class ReplaceElementContentPendingUpdate extends IPendingUpdate {
 	public readonly type: 'replaceElementContent';
 	constructor(readonly target: ConcreteNode, readonly text: Text) {

--- a/src/expressions/xquery-update/pendingUpdates/ReplaceElementContentPendingUpdate.ts
+++ b/src/expressions/xquery-update/pendingUpdates/ReplaceElementContentPendingUpdate.ts
@@ -1,6 +1,6 @@
 import { ConcreteNode } from '../../../domFacade/ConcreteNode';
-import { IPendingUpdate } from '../IPendingUpdate';
 import { Text } from '../../../types/Types';
+import { IPendingUpdate } from '../IPendingUpdate';
 
 export class ReplaceElementContentPendingUpdate extends IPendingUpdate {
 	public readonly type: 'replaceElementContent';

--- a/src/expressions/xquery-update/pulPrimitives.ts
+++ b/src/expressions/xquery-update/pulPrimitives.ts
@@ -11,6 +11,7 @@ import { RenamePendingUpdate } from './pendingUpdates/RenamePendingUpdate';
 import { ReplaceElementContentPendingUpdate } from './pendingUpdates/ReplaceElementContentPendingUpdate';
 import { ReplaceNodePendingUpdate } from './pendingUpdates/ReplaceNodePendingUpdate';
 import { ReplaceValuePendingUpdate } from './pendingUpdates/ReplaceValuePendingUpdate';
+import { Element, Text, Attr } from '../../types/Types';
 
 export const deletePu = (target: ConcreteNode) => {
 	return new DeletePendingUpdate(target);

--- a/src/expressions/xquery-update/pulPrimitives.ts
+++ b/src/expressions/xquery-update/pulPrimitives.ts
@@ -1,4 +1,5 @@
 import { ConcreteNode } from '../../domFacade/ConcreteNode';
+import { Attr, Element, Text } from '../../types/Types';
 import QName from '../dataTypes/valueTypes/QName';
 import { DeletePendingUpdate } from './pendingUpdates/DeletePendingUpdate';
 import { InsertAfterPendingUpdate } from './pendingUpdates/InsertAfterPendingUpdate';
@@ -11,7 +12,6 @@ import { RenamePendingUpdate } from './pendingUpdates/RenamePendingUpdate';
 import { ReplaceElementContentPendingUpdate } from './pendingUpdates/ReplaceElementContentPendingUpdate';
 import { ReplaceNodePendingUpdate } from './pendingUpdates/ReplaceNodePendingUpdate';
 import { ReplaceValuePendingUpdate } from './pendingUpdates/ReplaceValuePendingUpdate';
-import { Element, Text, Attr } from '../../types/Types';
 
 export const deletePu = (target: ConcreteNode) => {
 	return new DeletePendingUpdate(target);

--- a/src/expressions/xquery/AttributeConstructor.ts
+++ b/src/expressions/xquery/AttributeConstructor.ts
@@ -8,7 +8,7 @@ import createNodeValue from '../dataTypes/createNodeValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
 import Value from '../dataTypes/Value';
 import QName from '../dataTypes/valueTypes/QName';
-import { AsyncIterator, DONE_TOKEN, IterationHint, ready } from '../util/iterators';
+import { IAsyncIterator, DONE_TOKEN, IterationHint, ready } from '../util/iterators';
 import { evaluateQNameExpression } from './nameExpression';
 
 import StaticContext from '../StaticContext';
@@ -52,10 +52,10 @@ class AttributeConstructor extends Expression {
 
 	public evaluate(dynamicContext, executionParameters) {
 		const nodesFactory = executionParameters.nodesFactory;
-		let nameIterator: AsyncIterator<Value>;
+		let nameIterator: IAsyncIterator<Value>;
 		let name: QName;
 
-		let valueIterator: AsyncIterator<Value>;
+		let valueIterator: IAsyncIterator<Value>;
 
 		let done = false;
 		return sequenceFactory.create({

--- a/src/expressions/xquery/ElementConstructor.ts
+++ b/src/expressions/xquery/ElementConstructor.ts
@@ -9,7 +9,7 @@ import sequenceFactory from '../dataTypes/sequenceFactory';
 import Value from '../dataTypes/Value';
 import QName from '../dataTypes/valueTypes/QName';
 import concatSequences from '../util/concatSequences';
-import { AsyncIterator, DONE_TOKEN, IterationHint, ready } from '../util/iterators';
+import { DONE_TOKEN, IAsyncIterator, IterationHint, ready } from '../util/iterators';
 import AttributeConstructor from './AttributeConstructor';
 import parseContent from './ElementConstructorContent';
 import { evaluateQNameExpression } from './nameExpression';
@@ -77,7 +77,7 @@ class ElementConstructor extends Expression {
 		let childNodesSequences: ISequence[];
 		let allChildNodes: Value[][];
 
-		let nameIterator: AsyncIterator<Value>;
+		let nameIterator: IAsyncIterator<Value>;
 
 		let done = false;
 		return sequenceFactory.create({

--- a/src/expressions/xquery/nameExpression.ts
+++ b/src/expressions/xquery/nameExpression.ts
@@ -5,7 +5,7 @@ import Value from '../dataTypes/Value';
 import QName from '../dataTypes/valueTypes/QName';
 import ExecutionParameters from '../ExecutionParameters';
 import StaticContext from '../StaticContext';
-import { AsyncIterator } from '../util/iterators';
+import { IAsyncIterator } from '../util/iterators';
 import { errXPTY0004 } from '../XPathErrors';
 import { errXQDY0041, errXQDY0074 } from './XQueryErrors';
 
@@ -23,7 +23,7 @@ const isValidNCName = name => {
 export function evaluateNCNameExpression(
 	executionParameters: ExecutionParameters,
 	nameSequence: ISequence
-): AsyncIterator<Value> {
+): IAsyncIterator<Value> {
 	const name = nameSequence.atomize(executionParameters);
 	return name.switchCases({
 		singleton: seq => {
@@ -49,7 +49,7 @@ export function evaluateQNameExpression(
 	staticContext: StaticContext,
 	executionParameters: ExecutionParameters,
 	nameSequence: ISequence
-): AsyncIterator<Value> {
+): IAsyncIterator<Value> {
 	const name = nameSequence.atomize(executionParameters);
 	return name.switchCases({
 		singleton: seq => {

--- a/src/getBucketsForNode.ts
+++ b/src/getBucketsForNode.ts
@@ -1,5 +1,5 @@
 import { NODE_TYPES } from './domFacade/ConcreteNode';
-import { Element } from './types/Types';
+import { Attr, Element, Node } from './types/Types';
 
 /**
  * Get the buckets that apply to a given node.
@@ -13,19 +13,14 @@ import { Element } from './types/Types';
  * @param node - The node which buckets should be retrieved
  */
 export default function getBucketsForNode(
-	// TODO: Use the internal Node type for this parameter when we create one
-	node:
-		| {
-				nodeType: number;
-		  }
-		| { localName: string; nodeType: 1 | 2 }
+	node: Node
 ): string[] {
 	const buckets = [];
 
 	buckets.push('type-' + node.nodeType);
 
-	if (node.nodeType === 1 || node.nodeType === 2) {
-		buckets.push('name-' + (node as Element).localName);
+	if (node.nodeType === NODE_TYPES.ATTRIBUTE_NODE || node.nodeType === NODE_TYPES.ELEMENT_NODE) {
+		buckets.push('name-' + (node as (Attr|Element)).localName);
 	}
 
 	return buckets;

--- a/src/getBucketsForNode.ts
+++ b/src/getBucketsForNode.ts
@@ -1,4 +1,5 @@
 import { NODE_TYPES } from './domFacade/ConcreteNode';
+import { Element } from './types/Types';
 
 /**
  * Get the buckets that apply to a given node.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,8 @@
 import IDocumentWriter from './documentWriter/IDocumentWriter';
 import ExternalDomFacade from './domFacade/ExternalDomFacade';
 import IDomFacade from './domFacade/IDomFacade';
-<<<<<<< HEAD
 import evaluateUpdatingExpression, { UpdatingOptions } from './evaluateUpdatingExpression';
 import evaluateXPath, { Language, Options, ReturnType } from './evaluateXPath';
-=======
-import evaluateUpdatingExpression from './evaluateUpdatingExpression';
-import evaluateXPath from './evaluateXPath';
->>>>>>> Fix tslint warnings
 import evaluateXPathToArray from './evaluateXPathToArray';
 import evaluateXPathToAsyncIterator from './evaluateXPathToAsyncIterator';
 import evaluateXPathToBoolean from './evaluateXPathToBoolean';

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,8 @@ function compareSpecificity(xpathStringA: string, xpathStringB: string): -1 | 0 
  */
 const domFacade = new ExternalDomFacade() as IDomFacade;
 
+declare var window;
+
 /* istanbul ignore next */
 if (typeof window !== 'undefined') {
 	window['compareSpecificity'] = compareSpecificity;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,13 @@
 import IDocumentWriter from './documentWriter/IDocumentWriter';
 import ExternalDomFacade from './domFacade/ExternalDomFacade';
 import IDomFacade from './domFacade/IDomFacade';
+<<<<<<< HEAD
 import evaluateUpdatingExpression, { UpdatingOptions } from './evaluateUpdatingExpression';
 import evaluateXPath, { Language, Options, ReturnType } from './evaluateXPath';
+=======
+import evaluateUpdatingExpression from './evaluateUpdatingExpression';
+import evaluateXPath from './evaluateXPath';
+>>>>>>> Fix tslint warnings
 import evaluateXPathToArray from './evaluateXPathToArray';
 import evaluateXPathToAsyncIterator from './evaluateXPathToAsyncIterator';
 import evaluateXPathToBoolean from './evaluateXPathToBoolean';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import IDocumentWriter from './documentWriter/IDocumentWriter';
 import ExternalDomFacade from './domFacade/ExternalDomFacade';
 import IDomFacade from './domFacade/IDomFacade';
 import evaluateUpdatingExpression, { UpdatingOptions } from './evaluateUpdatingExpression';
-import evaluateXPath, { Language, Options, ReturnType } from './evaluateXPath';
+import evaluateXPath, { IReturnTypes, Language, Options, ReturnType } from './evaluateXPath';
 import evaluateXPathToArray from './evaluateXPathToArray';
 import evaluateXPathToAsyncIterator from './evaluateXPathToAsyncIterator';
 import evaluateXPathToBoolean from './evaluateXPathToBoolean';
@@ -26,6 +26,7 @@ import parseExpression from './parsing/parseExpression';
 import precompileXPath from './precompileXPath';
 import registerCustomXPathFunction from './registerCustomXPathFunction';
 import registerXQueryModule from './registerXQueryModule';
+import { Attr, CDATASection, CharacterData, Comment, Document, Element, Node, ProcessingInstruction, Text } from './types/Types';
 
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath');
@@ -112,15 +113,12 @@ if (typeof window !== 'undefined') {
 }
 
 export {
-	IDocumentWriter,
-	IDomFacade,
-	INodesFactory,
-	Language,
-	Options,
-	ReturnType,
-	UpdatingOptions,
-	compareSpecificity,
-	domFacade,
+	Attr,
+	CDATASection,
+	CharacterData,
+	Comment,
+	Element,
+	Document,
 	evaluateUpdatingExpression,
 	evaluateXPath,
 	evaluateXPathToArray,
@@ -136,6 +134,19 @@ export {
 	executePendingUpdateList,
 	getBucketForSelector,
 	getBucketsForNode,
+	IDocumentWriter,
+	IDomFacade,
+	INodesFactory,
+	IReturnTypes,
+	Language,
+	Node,
+	ProcessingInstruction,
+	Text,
+	ReturnType,
+	UpdatingOptions,
+	compareSpecificity,
+	domFacade,
+	Options,
 	precompileXPath,
 	registerCustomXPathFunction,
 	registerXQueryModule

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ function compareSpecificity(xpathStringA: string, xpathStringB: string): -1 | 0 
  */
 const domFacade = new ExternalDomFacade() as IDomFacade;
 
+// This declaration is needed, as we don't depend anymore on lib.dom.
 declare var window;
 
 /* istanbul ignore next */

--- a/src/nodesFactory/DomBackedNodesFactory.ts
+++ b/src/nodesFactory/DomBackedNodesFactory.ts
@@ -1,3 +1,4 @@
+import { Document } from '../types/Types';
 import INodesFactory from './INodesFactory';
 
 export default class DomBackedNodesFactory implements INodesFactory {

--- a/src/nodesFactory/INodesFactory.ts
+++ b/src/nodesFactory/INodesFactory.ts
@@ -1,6 +1,3 @@
-/**
- * @public
- */
 import {
 	Attr,
 	CDATASection,
@@ -11,6 +8,9 @@ import {
 	Text
 } from '../types/Types';
 
+/**
+ * @public
+ */
 export default interface INodesFactory {
 	createAttributeNS(namespaceURI: string, name: string): Attr;
 

--- a/src/nodesFactory/INodesFactory.ts
+++ b/src/nodesFactory/INodesFactory.ts
@@ -1,6 +1,16 @@
 /**
  * @public
  */
+import {
+	Attr,
+	CDATASection,
+	Comment,
+	Document,
+	Element,
+	ProcessingInstruction,
+	Text
+} from '../types/Types';
+
 export default interface INodesFactory {
 	createAttributeNS(namespaceURI: string, name: string): Attr;
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1163,7 +1163,7 @@ function renameExpression(ast, compilationOptions) {
 	return new RenameExpression(targetExpr, newNameExpr);
 }
 
-function replaceExpression(ast, compilationOptions) {
+function replaceExpression(ast: any, compilationOptions) {
 	const isReplaceValue = !!astHelper.getFirstChild(ast, 'replaceValue');
 	const targetExpr = compile(astHelper.followPath(ast, ['targetExpr', '*']), compilationOptions);
 	const replacementExpr = compile(

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1163,7 +1163,7 @@ function renameExpression(ast, compilationOptions) {
 	return new RenameExpression(targetExpr, newNameExpr);
 }
 
-function replaceExpression(ast: any, compilationOptions) {
+function replaceExpression(ast: IAST, compilationOptions) {
 	const isReplaceValue = !!astHelper.getFirstChild(ast, 'replaceValue');
 	const targetExpr = compile(astHelper.followPath(ast, ['targetExpr', '*']), compilationOptions);
 	const replacementExpr = compile(

--- a/src/parsing/compiledExpressionCache.ts
+++ b/src/parsing/compiledExpressionCache.ts
@@ -1,4 +1,4 @@
-import ExecutionSpecificStaticContext from 'src/expressions/ExecutionSpecificStaticContext';
+import ExecutionSpecificStaticContext from '../expressions/ExecutionSpecificStaticContext';
 import Expression from '../expressions/Expression';
 
 const compiledExpressionCache: { [s: string]: { [s: string]: CacheEntry[] } } = Object.create(null);

--- a/src/parsing/compiledExpressionCache.ts
+++ b/src/parsing/compiledExpressionCache.ts
@@ -1,5 +1,5 @@
-import Expression from '../expressions/Expression';
 import ExecutionSpecificStaticContext from 'src/expressions/ExecutionSpecificStaticContext';
+import Expression from '../expressions/Expression';
 
 const compiledExpressionCache: { [s: string]: { [s: string]: CacheEntry[] } } = Object.create(null);
 

--- a/src/parsing/compiledExpressionCache.ts
+++ b/src/parsing/compiledExpressionCache.ts
@@ -1,4 +1,5 @@
 import Expression from '../expressions/Expression';
+import ExecutionSpecificStaticContext from 'src/expressions/ExecutionSpecificStaticContext';
 
 const compiledExpressionCache: { [s: string]: { [s: string]: CacheEntry[] } } = Object.create(null);
 
@@ -12,7 +13,14 @@ class CacheEntry {
 	public referredNamespaces: { namespaceURI: string; prefix: string }[];
 	public referredVariables: { name: string }[];
 
-	constructor(referredNamespaces, referredVariables, compiledExpression, moduleImports) {
+	constructor(
+		referredNamespaces: { namespaceURI: string; prefix: string }[],
+		referredVariables: { name: string }[],
+		compiledExpression: Expression,
+		moduleImports:
+			| { namespaceURI: any; prefix: string }[]
+			| { namespaceURI: string; prefix: string }[]
+	) {
 		this.referredNamespaces = referredNamespaces;
 		this.referredVariables = referredVariables;
 		this.compiledExpression = compiledExpression;
@@ -20,7 +28,7 @@ class CacheEntry {
 	}
 }
 
-export function getAnyStaticCompilationResultFromCache(selectorString, language) {
+export function getAnyStaticCompilationResultFromCache(selectorString: string, language: string) {
 	const halfCompiledExpressionFromCache = halfCompiledExpressionCache[selectorString];
 	if (halfCompiledExpressionFromCache) {
 		return halfCompiledExpressionFromCache[language] || null;
@@ -41,9 +49,9 @@ export function getAnyStaticCompilationResultFromCache(selectorString, language)
 }
 
 export function storeHalfCompiledCompilationResultInCache(
-	selectorString,
-	language,
-	expressionInstance
+	selectorString: string,
+	language: string,
+	expressionInstance: Expression
 ) {
 	if (!halfCompiledExpressionCache[selectorString]) {
 		halfCompiledExpressionCache[selectorString] = {
@@ -55,11 +63,11 @@ export function storeHalfCompiledCompilationResultInCache(
 }
 
 export function getStaticCompilationResultFromCache(
-	selectorString,
-	language,
-	namespaceResolver,
-	variables,
-	moduleImports
+	selectorString: string,
+	language: string,
+	namespaceResolver: (namespace: string) => string | null,
+	variables: object,
+	moduleImports: { [x: string]: string }
 ) {
 	const cachesForExpression = compiledExpressionCache[selectorString];
 
@@ -123,7 +131,11 @@ export function getStaticCompilationResultFromCache(
 	};
 }
 
-function removeHalfCompiledExpression(selectorString, language, compiledExpression) {
+function removeHalfCompiledExpression(
+	selectorString: string,
+	language: string,
+	compiledExpression: Expression
+) {
 	const halfCompiledExpressionFromCache = halfCompiledExpressionCache[selectorString];
 	if (halfCompiledExpressionFromCache) {
 		const expression = halfCompiledExpressionFromCache[language];
@@ -134,11 +146,11 @@ function removeHalfCompiledExpression(selectorString, language, compiledExpressi
 }
 
 export function storeStaticCompilationResultInCache(
-	selectorString,
-	language,
-	executionStaticContext,
-	moduleImports,
-	compiledExpression
+	selectorString: string,
+	language: string,
+	executionStaticContext: ExecutionSpecificStaticContext,
+	moduleImports: { [x: string]: any },
+	compiledExpression: Expression
 ) {
 	removeHalfCompiledExpression(selectorString, language, compiledExpression);
 

--- a/src/parsing/globalModuleCache.ts
+++ b/src/parsing/globalModuleCache.ts
@@ -1,8 +1,8 @@
-import StaticContext, { FunctionDefinition } from "src/expressions/StaticContext";
+import StaticContext, { FunctionDefinition } from '../expressions/StaticContext';
 
 const loadedModulesByNamespaceURI = Object.create(null);
 
-export const loadModuleFile = (uri: string, moduleContents: { functionDeclarations: any; }) => {
+export const loadModuleFile = (uri: string, moduleContents: { functionDeclarations: any }) => {
 	let loadedModuleContents = loadedModulesByNamespaceURI[uri];
 	if (!loadedModuleContents) {
 		loadedModuleContents = loadedModulesByNamespaceURI[uri] = {
@@ -22,12 +22,17 @@ export const enhanceStaticContextWithModule = (staticContext: StaticContext, uri
 		throw new Error(`XQST0051: No modules found with the namespace uri ${uri}`);
 	}
 
-	moduleContents.functionDeclarations.forEach((functionDeclaration: { localName: string; arity: number; functionDefinition: FunctionDefinition; }) =>
-		staticContext.registerFunctionDefinition(
-			uri,
-			functionDeclaration.localName,
-			functionDeclaration.arity,
-			functionDeclaration.functionDefinition
-		)
+	moduleContents.functionDeclarations.forEach(
+		(functionDeclaration: {
+			arity: number;
+			functionDefinition: FunctionDefinition;
+			localName: string;
+		}) =>
+			staticContext.registerFunctionDefinition(
+				uri,
+				functionDeclaration.localName,
+				functionDeclaration.arity,
+				functionDeclaration.functionDefinition
+			)
 	);
 };

--- a/src/parsing/globalModuleCache.ts
+++ b/src/parsing/globalModuleCache.ts
@@ -1,6 +1,8 @@
+import StaticContext, { FunctionDefinition } from "src/expressions/StaticContext";
+
 const loadedModulesByNamespaceURI = Object.create(null);
 
-export const loadModuleFile = (uri, moduleContents) => {
+export const loadModuleFile = (uri: string, moduleContents: { functionDeclarations: any; }) => {
 	let loadedModuleContents = loadedModulesByNamespaceURI[uri];
 	if (!loadedModuleContents) {
 		loadedModuleContents = loadedModulesByNamespaceURI[uri] = {
@@ -13,14 +15,14 @@ export const loadModuleFile = (uri, moduleContents) => {
 	);
 };
 
-export const enhanceStaticContextWithModule = (staticContext, uri) => {
+export const enhanceStaticContextWithModule = (staticContext: StaticContext, uri: string) => {
 	const moduleContents = loadedModulesByNamespaceURI[uri];
 
 	if (!moduleContents) {
 		throw new Error(`XQST0051: No modules found with the namespace uri ${uri}`);
 	}
 
-	moduleContents.functionDeclarations.forEach(functionDeclaration =>
+	moduleContents.functionDeclarations.forEach((functionDeclaration: { localName: string; arity: number; functionDefinition: FunctionDefinition; }) =>
 		staticContext.registerFunctionDefinition(
 			uri,
 			functionDeclaration.localName,

--- a/src/parsing/processProlog.ts
+++ b/src/parsing/processProlog.ts
@@ -7,12 +7,12 @@ import createDoublyIterableSequence from '../expressions/util/createDoublyIterab
 
 import { enhanceStaticContextWithModule } from './globalModuleCache';
 
+import ISequence from '../expressions/dataTypes/ISequence';
 import DynamicContext from '../expressions/DynamicContext';
 import ExecutionParameters from '../expressions/ExecutionParameters';
-import { errXQST0070 } from '../expressions/xquery/XQueryErrors';
 import Expression from '../expressions/Expression';
-import FunctionDefinitionType from 'src/expressions/functions/FunctionDefinitionType';
-import ISequence from 'src/expressions/dataTypes/ISequence';
+import FunctionDefinitionType from '../expressions/functions/FunctionDefinitionType';
+import { errXQST0070 } from '../expressions/xquery/XQueryErrors';
 
 const RESERVED_FUNCTION_NAMESPACE_URIS = [
 	'http://www.w3.org/XML/1998/namespace',
@@ -116,7 +116,7 @@ export default function processProlog(
 	});
 
 	astHelper.getChildren(prolog, 'functionDecl').forEach(declaration => {
-		const functionName = astHelper.getFirstChild(declaration, 'functionName')!;
+		const functionName = astHelper.getFirstChild(declaration, 'functionName');
 		const declarationPrefix = astHelper.getAttribute(functionName, 'prefix');
 		let declarationNamespaceURI = astHelper.getAttribute(functionName, 'URI');
 		const declarationLocalName = astHelper.getTextContent(functionName);
@@ -131,7 +131,7 @@ export default function processProlog(
 			}
 		}
 
-		if (RESERVED_FUNCTION_NAMESPACE_URIS.includes(declarationNamespaceURI)!) {
+		if (RESERVED_FUNCTION_NAMESPACE_URIS.includes(declarationNamespaceURI)) {
 			throw new Error(
 				'XQST0045: Functions and variables may not be declared in one of the reserved namespace URIs.'
 			);
@@ -140,7 +140,7 @@ export default function processProlog(
 		// Functions are public unless they're private
 		const isPublicDeclaration = astHelper
 			.getChildren(declaration, 'annotation')
-			.map(annotation => astHelper.getFirstChild(annotation, 'annotationName')!)
+			.map(annotation => astHelper.getFirstChild(annotation, 'annotationName'))
 			.every(
 				annotationName =>
 					!astHelper.getAttribute(annotationName, 'URI') &&
@@ -152,14 +152,14 @@ export default function processProlog(
 		}
 
 		// functionBody always has a single expression
-		const body = astHelper.getFirstChild(declaration, 'functionBody')![1];
+		const body = astHelper.getFirstChild(declaration, 'functionBody')[1];
 		const returnType = astHelper.getTypeDeclaration(declaration);
 		const params = astHelper.getChildren(
-			astHelper.getFirstChild(declaration, 'paramList')!,
+			astHelper.getFirstChild(declaration, 'paramList'),
 			'param'
 		);
-		const paramNames = params.map(param => astHelper.getFirstChild(param, 'varName')!);
-		const paramTypes = params.map(param => astHelper.getTypeDeclaration(param)!);
+		const paramNames = params.map(param => astHelper.getFirstChild(param, 'varName'));
+		const paramTypes = params.map(param => astHelper.getTypeDeclaration(param));
 
 		if (
 			staticContext.lookupFunction(
@@ -244,9 +244,9 @@ export default function processProlog(
 		}
 	});
 
-	const registeredVariables: { namespaceURI: null | string; localName: string }[] = [];
+	const registeredVariables: { localName: string; namespaceURI: null | string }[] = [];
 	astHelper.getChildren(prolog, 'varDecl').forEach(varDecl => {
-		const varName = astHelper.getQName(astHelper.getFirstChild(varDecl, 'varName')!)!;
+		const varName = astHelper.getQName(astHelper.getFirstChild(varDecl, 'varName'));
 		const external = astHelper.getFirstChild(varDecl, 'external');
 		if (!external || astHelper.getFirstChild(external, 'varValue')) {
 			throw new Error(

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -21,9 +21,9 @@ export default function staticallyCompileXPath(
 		allowXQuery: boolean | undefined;
 		debug: boolean | undefined;
 	},
-	namespaceResolver: (namespace: string) => string | null,
+	namespaceResolver: (namespace: string) => (string | null),
 	variables: object,
-	moduleImports: object
+	moduleImports: {[namespaceURI: string]: string}
 ): Expression {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 
@@ -59,7 +59,7 @@ export default function staticallyCompileXPath(
 		}
 
 		const prolog = astHelper.getFirstChild(mainModule, 'prolog');
-		const queryBodyContents = astHelper.followPath(mainModule, ['queryBody', '*']);
+		const queryBodyContents = astHelper.followPath(mainModule, ['queryBody', '*'])!;
 
 		if (prolog) {
 			if (!compilationOptions.allowXQuery) {

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -21,9 +21,9 @@ export default function staticallyCompileXPath(
 		allowXQuery: boolean | undefined;
 		debug: boolean | undefined;
 	},
-	namespaceResolver: (namespace: string) => (string | null),
+	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
-	moduleImports: {[namespaceURI: string]: string}
+	moduleImports: { [namespaceURI: string]: string }
 ): Expression {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 
@@ -59,7 +59,7 @@ export default function staticallyCompileXPath(
 		}
 
 		const prolog = astHelper.getFirstChild(mainModule, 'prolog');
-		const queryBodyContents = astHelper.followPath(mainModule, ['queryBody', '*'])!;
+		const queryBodyContents = astHelper.followPath(mainModule, ['queryBody', '*']);
 
 		if (prolog) {
 			if (!compilationOptions.allowXQuery) {

--- a/src/registerCustomXPathFunction.ts
+++ b/src/registerCustomXPathFunction.ts
@@ -9,9 +9,10 @@ import {
 	registerStaticallyKnownNamespace,
 	staticallyKnownNamespaceByPrefix
 } from './expressions/staticallyKnownNamespaces';
+import ISequence from './expressions/dataTypes/ISequence';
 
 function adaptXPathValueToJavascriptValue(
-	valueSequence: any,
+	valueSequence: ISequence,
 	sequenceType: string
 ): any | null | any[] {
 	switch (sequenceType[sequenceType.length - 1]) {
@@ -19,7 +20,7 @@ function adaptXPathValueToJavascriptValue(
 			if (valueSequence.isEmpty()) {
 				return null;
 			}
-			return valueSequence.first().value;
+			return valueSequence.first()!.value;
 
 		case '*':
 		case '+':
@@ -31,7 +32,7 @@ function adaptXPathValueToJavascriptValue(
 			});
 
 		default:
-			return valueSequence.first().value;
+			return valueSequence.first()!.value;
 	}
 }
 
@@ -94,10 +95,11 @@ export default function registerCustomXPathFunction(
 
 		// Adapt the domFacade into another object to prevent passing everything. The closure compiler might rename some variables otherwise.
 		// Since the interface for domFacade (IDomFacade) is marked as extern, it will not be changed
-		const dynamicContextAdapter = {};
-		dynamicContextAdapter['domFacade'] = executionParameters.domFacade.unwrap();
+		const dynamicContextAdapter: DomFacadeWrapper = {
+			['domFacade']: executionParameters.domFacade.unwrap()
+		};
 
-		const jsResult = callback.apply(undefined, [dynamicContextAdapter].concat(newArguments));
+		const jsResult = callback.apply(undefined, [dynamicContextAdapter, ...newArguments]);
 		const xpathResult = adaptJavaScriptValueToXPathValue(jsResult, returnType);
 
 		return xpathResult;

--- a/src/registerCustomXPathFunction.ts
+++ b/src/registerCustomXPathFunction.ts
@@ -12,7 +12,7 @@ import {
 } from './expressions/staticallyKnownNamespaces';
 
 type DomFacadeWrapper = {
-    domFacade: IDomFacade;
+	domFacade: IDomFacade;
 };
 
 function adaptXPathValueToJavascriptValue(

--- a/src/registerCustomXPathFunction.ts
+++ b/src/registerCustomXPathFunction.ts
@@ -3,13 +3,17 @@ import isSubtypeOf from './expressions/dataTypes/isSubtypeOf';
 import { registerFunction } from './expressions/functions/functionRegistry';
 
 import IDomFacade from './domFacade/IDomFacade';
+import ISequence from './expressions/dataTypes/ISequence';
 import DynamicContext from './expressions/DynamicContext';
 import ExecutionParameters from './expressions/ExecutionParameters';
 import {
 	registerStaticallyKnownNamespace,
 	staticallyKnownNamespaceByPrefix
 } from './expressions/staticallyKnownNamespaces';
-import ISequence from './expressions/dataTypes/ISequence';
+
+type DomFacadeWrapper = {
+    domFacade: IDomFacade;
+};
 
 function adaptXPathValueToJavascriptValue(
 	valueSequence: ISequence,

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -20,10 +20,10 @@ export default function registerXQueryModule(moduleString: string): string {
 	if (!libraryModule) {
 		throw new Error('XQuery module must be declared in a library module.');
 	}
-	const moduleDecl = astHelper.getFirstChild(libraryModule, 'moduleDecl');
-	const uriNode = astHelper.getFirstChild(moduleDecl, 'uri');
+	const moduleDecl = astHelper.getFirstChild(libraryModule, 'moduleDecl')!;
+	const uriNode = astHelper.getFirstChild(moduleDecl, 'uri')!;
 	const moduleTargetNamespaceURI = astHelper.getTextContent(uriNode);
-	const prefixNode = astHelper.getFirstChild(moduleDecl, 'prefix');
+	const prefixNode = astHelper.getFirstChild(moduleDecl, 'prefix')!;
 	const moduleTargetPrefix = astHelper.getTextContent(prefixNode);
 
 	const staticContext = new StaticContext(

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -1,7 +1,13 @@
+/**
+ * @public
+ */
 export type Node = {
 	nodeType: number;
 };
 
+/**
+ * @public
+ */
 export type Attr = Node & {
 	localName: string;
 	name: string;
@@ -11,12 +17,24 @@ export type Attr = Node & {
 	value: string;
 };
 
+/**
+ * @public
+ */
 export type CharacterData = Node & { data: string };
 
+/**
+ * @public
+ */
 export type CDATASection = CharacterData;
 
+/**
+ * @public
+ */
 export type Comment = CharacterData;
 
+/**
+ * @public
+ */
 export type Document = Node & {
 	implementation: {
 		createDocument(namespaceURI: null, qualifiedNameStr: null, documentType: null): Document;
@@ -29,6 +47,9 @@ export type Document = Node & {
 	createTextNode(data: string): Text;
 };
 
+/**
+ * @public
+ */
 export type Element = Node & {
 	data: string;
 	localName: string;
@@ -37,9 +58,15 @@ export type Element = Node & {
 	prefix: string;
 };
 
+/**
+ * @public
+ */
 export type ProcessingInstruction = CharacterData & {
 	nodeName: string;
 	target: string;
 };
 
+/**
+ * @public
+ */
 export type Text = CharacterData;

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -51,7 +51,6 @@ export type Document = Node & {
  * @public
  */
 export type Element = Node & {
-	data: string;
 	localName: string;
 	namespaceURI: string;
 	nodeName: string;

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -1,0 +1,45 @@
+export type Node = {
+	nodeType: number;
+};
+
+export type Attr = Node & {
+	localName: string;
+	name: string;
+	namespaceURI: string;
+	nodeName: string;
+	prefix: string;
+	value: string;
+};
+
+export type CharacterData = Node & { data: string };
+
+export type CDATASection = CharacterData;
+
+export type Comment = CharacterData;
+
+export type Document = Node & {
+	implementation: {
+		createDocument(namespaceURI: null, qualifiedNameStr: null, documentType: null): Document;
+	};
+	createAttributeNS(namespaceURI: string, name: string): Attr;
+	createCDATASection(contents: string): CDATASection;
+	createComment(data: string): Comment;
+	createElementNS(namespaceURI: string, qualifiedName: string): Element;
+	createProcessingInstruction(target: string, data: string): ProcessingInstruction;
+	createTextNode(data: string): Text;
+};
+
+export type Element = Node & {
+	data: string;
+	localName: string;
+	namespaceURI: string;
+	nodeName: string;
+	prefix: string;
+};
+
+export type ProcessingInstruction = CharacterData & {
+	nodeName: string;
+	target: string;
+};
+
+export type Text = CharacterData;

--- a/test/qt3tests.ts
+++ b/test/qt3tests.ts
@@ -148,9 +148,9 @@ function createAsserter(baseUrl, assertNode, language) {
 			const errorCode = evaluateXPathToString('@code', assertNode);
 			return (
 				xpath: string,
-				contextNode: Element,
+				contextNode: slimdom.Element,
 				variablesInScope: object,
-				namespaceResolver: (string) => string
+				namespaceResolver: (str: string) => string
 			) =>
 				chai.assert.throws(
 					() => {

--- a/test/specs/expressions/dataTypes/castToType.tests.ts
+++ b/test/specs/expressions/dataTypes/castToType.tests.ts
@@ -38,7 +38,7 @@ import DayTimeDuration from 'fontoxpath/expressions/dataTypes/valueTypes/DayTime
 
 describe('castToType()', () => {
 	before(() => {
-		if (typeof atob === 'undefined') {
+		if (typeof (global as any).atob === 'undefined') {
 			(global as any).atob = function (b64Encoded) {
 				return new Buffer(b64Encoded, 'base64').toString();
 			};

--- a/test/specs/parsing/axes/DescendantAxis.tests.ts
+++ b/test/specs/parsing/axes/DescendantAxis.tests.ts
@@ -5,6 +5,7 @@ import jsonMlMapper from 'test-helpers/jsonMlMapper';
 import {
 	evaluateXPathToNodes
 } from 'fontoxpath';
+import { Element } from 'fontoxpath/types/Types';
 
 let documentNode;
 beforeEach(() => {
@@ -68,7 +69,7 @@ describe('descendant-or-self', () => {
 			['a', ['a-a'], ['a-b']],
 			['b', ['b-a'], ['b-b']]
 		], documentNode);
-		chai.assert.deepEqual(evaluateXPathToNodes('//*[name() = "root" or name() => starts-with("a") or name() => starts-with("b")]', documentNode).map(node => node.nodeName), ['root', 'a', 'a-a', 'a-b', 'b', 'b-a', 'b-b']);
+		chai.assert.deepEqual(evaluateXPathToNodes('//*[name() = "root" or name() => starts-with("a") or name() => starts-with("b")]', documentNode).map((node: Element) => node.localName), ['root', 'a', 'a-a', 'a-b', 'b', 'b-a', 'b-b']);
 	});
 
 	it('throws the correct error if context is absent', () => {

--- a/test/specs/parsing/axes/PrecedingAxis.tests.ts
+++ b/test/specs/parsing/axes/PrecedingAxis.tests.ts
@@ -24,10 +24,10 @@ describe('preceding', () => {
 			evaluateXPathToNodes(
 				'preceding::someOtherElement',
 				documentNode.documentElement.lastChild
-			).map(node => (node as Element).outerHTML),
+			).map(node => (node as slimdom.Element).outerHTML),
 			[
-				(documentNode.documentElement.firstChild as Element).outerHTML,
-				(documentNode.documentElement.firstChild.firstChild as Element).outerHTML
+				(documentNode.documentElement.firstChild as slimdom.Element).outerHTML,
+				(documentNode.documentElement.firstChild.firstChild as slimdom.Element).outerHTML
 			]
 		);
 	});

--- a/test/specs/parsing/evaluateXPath.tests.ts
+++ b/test/specs/parsing/evaluateXPath.tests.ts
@@ -415,7 +415,7 @@ describe('evaluateXPath', () => {
 					null,
 					null,
 					{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
-				) as Element).outerHTML,
+				) as slimdom.Element).outerHTML,
 				'<element>Some text, a <?processing instruction ?> and a <!--comment-->&lt;,&amp;and)</element>'
 			);
 

--- a/test/specs/parsing/tests/KindTest.tests.ts
+++ b/test/specs/parsing/tests/KindTest.tests.ts
@@ -46,18 +46,6 @@ describe('KindTest', () => {
 		chai.assert.isTrue(evaluateXPathToBoolean('self::text()', documentNode.documentElement.firstChild));
 	});
 
-	if (typeof DOMParser !== 'undefined') {
-		it('can select any element -> element(prefix:name)', () => {
-			const browserDocument = new DOMParser().parseFromString('<xml xmlns:prefix="http://example.com/ns"><prefix:element/></xml>', 'text/xml');
-			chai.assert.isTrue(evaluateXPathToBoolean('self::element(prefix:element)', browserDocument.documentElement.firstChild));
-		});
-
-		it('regards CDATA nodes as text nodes', () => {
-			const browserDocument = new DOMParser().parseFromString('<xml><![CDATA[Some CData]]></xml>', 'text/xml');
-			chai.assert.isTrue(evaluateXPathToBoolean('child::text()', browserDocument.documentElement));
-		});
-	}
-
 	it('can select any PI -> processing-instruction()', () => {
 		jsonMlMapper.parse([
 			'someOtherParentElement',

--- a/test/specs/parsing/xquery-updating/TransformExpression.tests.ts
+++ b/test/specs/parsing/xquery-updating/TransformExpression.tests.ts
@@ -4,6 +4,7 @@ import { slimdom, sync } from 'slimdom-sax-parser';
 import IDomFacade from '../../../../src/domFacade/IDomFacade';
 import assertUpdateList from './assertUpdateList';
 import DomBackedNodesFactory from 'fontoxpath/nodesFactory/DomBackedNodesFactory';
+import { Document } from 'slimdom';
 
 let documentNode: Document;
 beforeEach(() => {
@@ -188,17 +189,17 @@ return ($a, replace node element with <replacement/>)
 		const a = documentNode.createElement('a');
 
 		// <xml><a/></xml>
-		const getChildNode = (node: Node) =>
+		const getChildNode = (node: slimdom.Node) =>
 			node === documentNode ? xml : node === xml ? a : null;
 		const myDomFacade: IDomFacade = {
 			getAllAttributes: () => [],
 			getAttribute: () => null,
-			getChildNodes: (node: Node) => [getChildNode(node)],
+			getChildNodes: (node: slimdom.Node) => [getChildNode(node)],
 			getData: () => '',
 			getFirstChild: getChildNode,
 			getLastChild: getChildNode,
 			getNextSibling: () => null,
-			getParentNode: (node: Node) => (node === a ? xml : node === xml ? documentNode : null),
+			getParentNode: (node: slimdom.Node) => (node === a ? xml : node === xml ? documentNode : null),
 			getPreviousSibling: () => null
 		};
 
@@ -217,7 +218,7 @@ return ($a, replace node element with <replacement/>)
 
 	it('throws when a target of in the pul of modify is not a clone', async () => {
 		documentNode.appendChild(documentNode.createElement('a'));
-		let error;
+		let error: Error|null;
 		try {
 			await evaluateUpdatingExpression(
 				'copy $newVar := a modify replace node a with <b/> return $newVar',
@@ -230,7 +231,7 @@ return ($a, replace node element with <replacement/>)
 			error = err;
 		}
 
-		chai.assert.match(error.message, new RegExp('XUDY0014'));
+		chai.assert.match(error!.message, new RegExp('XUDY0014'));
 	});
 
 	it('transforms something with something asynchronous', async () => {

--- a/test/specs/parsing/xquery/AttributeConstructor.tests.ts
+++ b/test/specs/parsing/xquery/AttributeConstructor.tests.ts
@@ -11,13 +11,13 @@ beforeEach(() => {
 
 describe('AttributeConstructor', () => {
 	it('can create an attribute', () => {
-		const attribute = evaluateXPathToFirstNode(
+		const attribute = evaluateXPathToFirstNode<slimdom.Attr>(
 			'attribute attr {"val"}',
 			documentNode,
 			undefined,
 			{},
 			{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
-		) as Attr;
+		);
 
 		chai.assert.equal(attribute.nodeType, 2);
 		chai.assert.equal(attribute.name, 'attr');

--- a/test/specs/parsing/xquery/ElementConstructor.tests.ts
+++ b/test/specs/parsing/xquery/ElementConstructor.tests.ts
@@ -159,26 +159,26 @@ describe('ElementConstructor', () => {
 
 	it('correctly handles multiple textNodes', () => {
 		chai.assert.equal(
-			(evaluateXPathToFirstNode(
+			evaluateXPathToFirstNode<slimdom.Element>(
 				'<e>{1}A{1}</e>',
 				documentNode,
 				undefined,
 				{},
 				{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
-			) as Element).outerHTML,
+			).outerHTML,
 			'<e>1A1</e>'
 		);
 	});
 
 	it('accepts CDataSections', () => {
 		chai.assert.equal(
-			(evaluateXPathToFirstNode(
+			evaluateXPathToFirstNode<slimdom.Element>(
 				'<e><![CDATA[Some CDATA]]></e>',
 				documentNode,
 				undefined,
 				{},
 				{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
-			) as Element).outerHTML,
+			).outerHTML,
 			'<e>Some CDATA</e>'
 		);
 	});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -7,6 +7,7 @@
 			"fontoxpath/*": ["src/*"],
 			"test-helpers/*": ["test/helpers/*"]
 		},
+		"strict": false,
 		"inlineSources": true,
 		"types": ["mocha", "node"]
 	},

--- a/test/xQueryXUtils.ts
+++ b/test/xQueryXUtils.ts
@@ -15,7 +15,7 @@ export function buildTestCase(testCase, loadXQuery, loadXQueryX, skippableTests,
 
 		let jsonMl;
 		try {
-			jsonMl = parse(xQuery);
+			jsonMl = parse(xQuery, { xquery: true, outputDebugInfo: false });
 		} catch (err) {
 			if (err.location) {
 				const start = err.location.start.offset;
@@ -50,7 +50,7 @@ export function buildTestCase(testCase, loadXQuery, loadXQueryX, skippableTests,
 			skippableTests.push(`${testCase},Expected XML could not be parsed`);
 			throw e;
 		}
-		const nonSignificantWhitespace = evaluateXPathToNodes(
+		const nonSignificantWhitespace = evaluateXPathToNodes<slimdom.Node>(
 			'//*/text()[starts-with(., "&#xA;") and normalize-space(.)=""]',
 			expected,
 			null,

--- a/test/xqutsTests.ts
+++ b/test/xqutsTests.ts
@@ -333,7 +333,7 @@ async function runTestCase(testName, testCase) {
 }
 
 function buildTestCases(testGroup) {
-	(evaluateXPathToNodes('test-group | test-case', testGroup) as Element[]).forEach(test => {
+	(evaluateXPathToNodes('test-group | test-case', testGroup) as slimdom.Element[]).forEach(test => {
 		switch (test.localName) {
 			case 'test-group': {
 				const groupName = evaluateXPathToString(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
 	"compilerOptions": {
 		"outDir": "./built",
 		"baseUrl": ".",
-		"lib": ["dom", "es6", "es2017", "esnext.asynciterable"],
+		"lib": ["es6", "es2017", "esnext.asynciterable"],
 		"target": "es2017",
 		"module": "commonjs",
 		"inlineSourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"module": "commonjs",
 		"inlineSourceMap": true,
 		"declaration": true,
-		"strict": true,
+		"strict": false,
 		"inlineSources": true
 	},
 	"include": ["./src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"module": "commonjs",
 		"inlineSourceMap": true,
 		"declaration": true,
+		"strict": true,
 		"inlineSources": true
 	},
 	"include": ["./src/**/*"]


### PR DESCRIPTION
I have added our own node type which contains the minimal properties we use with a generic type. This allows us to use FontoXPath in other TypeScript libraries without having to cast nodes around.