### PR TITLE
Transform external variables to xs:doubles

### DIFF
--- a/src/expressions/adaptJavaScriptValueToXPathValue.ts
+++ b/src/expressions/adaptJavaScriptValueToXPathValue.ts
@@ -24,7 +24,7 @@ function adaptItemToXPathValue(value: any): Value | null {
 		case 'boolean':
 			return value ? trueBoolean : falseBoolean;
 		case 'number':
-			return createAtomicValue(value, 'xs:decimal');
+			return createAtomicValue(value, 'xs:double');
 		case 'string':
 			return createAtomicValue(value, 'xs:string');
 		case 'object':

--- a/test/specs/expressions/adaptJavaScriptValueToXPathValue.tests.ts
+++ b/test/specs/expressions/adaptJavaScriptValueToXPathValue.tests.ts
@@ -146,7 +146,7 @@ describe('adaptJavaScriptValueToXPathValue', () => {
 		it('can automatically convert numbers', () => {
 			const xpathSequence = adaptJavaScriptValueToXPathValue(1.0, 'item()');
 			chai.assert(xpathSequence.isSingleton(), 'is a singleton sequence');
-			chai.assert(xpathSequence.first().type === ('xs:decimal'), 'is a decimal');
+			chai.assert(xpathSequence.first().type === ('xs:double'), 'is a double');
 			chai.assert.equal(xpathSequence.first().value, 1.0, 'is 1.0');
 		});
 


### PR DESCRIPTION
This aligns more with the [parse-json](https://www.w3.org/TR/xpath-functions-31/#func-parse-json) function, which is like our JavaScript -> XPath conversion.

Fixes #114