### PR TITLE
Make debug mode and disabling cache a separate thing

### DIFF
--- a/demo/main.ts
+++ b/demo/main.ts
@@ -114,7 +114,8 @@ function jsonXmlReplacer(_key: string, value: any): any {
 
 async function runUpdatingXQuery(script: string) {
 	const result = await fontoxpath.evaluateUpdatingExpression(script, xmlDoc, null, null, {
-		debug: true
+		debug: true,
+		disableCache: true
 	});
 
 	resultText.innerText = JSON.stringify(result, jsonXmlReplacer, '  ');
@@ -126,6 +127,7 @@ async function runNormalXPath(script: string, asXQuery: boolean) {
 	const raw = [];
 	const it = fontoxpath.evaluateXPathToAsyncIterator(script, xmlDoc, null, null, {
 		debug: true,
+		disableCache: true,
 		language: asXQuery
 			? fontoxpath.evaluateXPath.XQUERY_3_1_LANGUAGE
 			: fontoxpath.evaluateXPath.XPATH_3_1_LANGUAGE

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -15,6 +15,7 @@ import INodesFactory from './nodesFactory/INodesFactory';
  */
 export type UpdatingOptions = {
 	debug?: boolean;
+	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
@@ -56,7 +57,8 @@ export default async function evaluateUpdatingExpression(
 			{
 				allowUpdating: true,
 				allowXQuery: true,
-				debug: options['debug']
+				debug: !!options['debug'],
+				disableCache: !!options['disableCache']
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -135,6 +135,7 @@ function transformXPathItemToJavascriptObject(value, dynamicContext) {
 export type Options = {
 	currentContext?: any;
 	debug?: boolean;
+	disableCache?: boolean;
 	language?: Language;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
@@ -224,7 +225,8 @@ function evaluateXPath<TNode extends Node, TReturnType extends keyof IReturnType
 			{
 				allowUpdating: false,
 				allowXQuery: options['language'] === Language.XQUERY_3_1_LANGUAGE,
-				debug: !!options['debug']
+				debug: !!options['debug'],
+				disableCache: !!options['disableCache']
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -55,6 +55,7 @@ export default function buildEvaluationContext(
 		allowUpdating: boolean;
 		allowXQuery: boolean;
 		debug: boolean;
+		disableCache: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import registerXQueryModule from './registerXQueryModule';
 import { Attr, CDATASection, CharacterData, Comment, Document, Element, Node, ProcessingInstruction, Text } from './types/Types';
 
 function parseXPath(xpathString: string) {
-	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath');
+	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {
 		return cachedExpression;
 	}
@@ -46,7 +46,7 @@ function parseXPath(xpathString: string) {
 		allowXQuery: false
 	});
 
-	storeHalfCompiledCompilationResultInCache(xpathString, 'XPath', expression);
+	storeHalfCompiledCompilationResultInCache(xpathString, 'XPath', expression, false);
 
 	return expression;
 }

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -20,6 +20,7 @@ export default function staticallyCompileXPath(
 		allowUpdating: boolean | undefined;
 		allowXQuery: boolean | undefined;
 		debug: boolean | undefined;
+		disableCache: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
@@ -27,16 +28,16 @@ export default function staticallyCompileXPath(
 ): Expression {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 
-	let fromCache = null;
-	if (!compilationOptions.debug) {
-		fromCache = getStaticCompilationResultFromCache(
-			xpathString,
-			language,
-			namespaceResolver,
-			variables,
-			moduleImports
-		);
-	}
+	const fromCache = compilationOptions.disableCache
+		? null
+		: getStaticCompilationResultFromCache(
+				xpathString,
+				language,
+				namespaceResolver,
+				variables,
+				moduleImports,
+				compilationOptions.debug
+		  );
 
 	const executionSpecificStaticContext = new ExecutionSpecificStaticContext(
 		namespaceResolver,
@@ -83,13 +84,14 @@ export default function staticallyCompileXPath(
 
 		expression.performStaticEvaluation(rootStaticContext);
 
-		if (!compilationOptions.debug) {
+		if (!compilationOptions.disableCache) {
 			storeStaticCompilationResultInCache(
 				xpathString,
 				language,
 				executionSpecificStaticContext,
 				moduleImports,
-				expression
+				expression,
+				compilationOptions.debug
 			);
 		}
 	}


### PR DESCRIPTION
The better error traces are realy useful when debugging
XPaths. Disabling caching is useful when working on the parser, but
makes performance very bad.

By making them separate, debugging XPaths will be easier.