### PR TITLE
Add position to rethrown errors

### DIFF
--- a/src/evaluationUtils/PositionedError.ts
+++ b/src/evaluationUtils/PositionedError.ts
@@ -1,7 +1,6 @@
 import { SourceRange } from '../expressions/debug/StackTraceGenerator';
 
 export class PositionedError extends Error {
-	
 	public readonly position: SourceRange;
 
 	constructor(message: string, position: SourceRange) {

--- a/src/evaluationUtils/PositionedError.ts
+++ b/src/evaluationUtils/PositionedError.ts
@@ -1,0 +1,8 @@
+import { SourceRange } from '../expressions/debug/StackTraceGenerator';
+export class PositionedError extends Error {
+	public readonly position: SourceRange;
+	constructor(message: string, position: SourceRange) {
+		super(message);
+		this.position = position;
+	}
+}

--- a/src/evaluationUtils/PositionedError.ts
+++ b/src/evaluationUtils/PositionedError.ts
@@ -1,6 +1,9 @@
 import { SourceRange } from '../expressions/debug/StackTraceGenerator';
+
 export class PositionedError extends Error {
+	
 	public readonly position: SourceRange;
+
 	constructor(message: string, position: SourceRange) {
 		super(message);
 		this['position'] = {

--- a/src/evaluationUtils/PositionedError.ts
+++ b/src/evaluationUtils/PositionedError.ts
@@ -3,6 +3,17 @@ export class PositionedError extends Error {
 	public readonly position: SourceRange;
 	constructor(message: string, position: SourceRange) {
 		super(message);
-		this.position = position;
+		this['position'] = {
+			['end']: {
+				['column']: position.end.column,
+				['line']: position.end.line,
+				['offset']: position.end.offset
+			},
+			['start']: {
+				['column']: position.start.column,
+				['line']: position.start.line,
+				['offset']: position.start.offset
+			}
+		};
 	}
 }

--- a/src/evaluationUtils/printAndRethrowError.ts
+++ b/src/evaluationUtils/printAndRethrowError.ts
@@ -1,4 +1,5 @@
 import { StackTraceEntry } from '../expressions/debug/StackTraceEntry';
+import { SourceRange } from '../expressions/debug/StackTraceGenerator';
 
 function getNumberStringLength(i: number) {
 	return Math.floor(Math.log10(i)) + 1;
@@ -52,8 +53,17 @@ export function printAndRethrowError(selector: string, error: Error | StackTrace
 
 	const stackTrace = stackEntry.makeStackTrace().join('\n');
 	const errorMessage = lines.join('\n') + '\n\n' + stackTrace;
-	const newError = new Error(errorMessage);
+	const newError = new PositionedError(errorMessage, errorLocation);
 	// tslint:disable-next-line:no-console We do want to write these to error.
 	console.error(errorMessage);
 	throw newError;
+}
+
+class PositionedError extends Error {
+	public readonly position: SourceRange;
+
+	constructor(message: string, position: SourceRange) {
+		super(message);
+		this.position = position;
+	}
 }

--- a/src/evaluationUtils/printAndRethrowError.ts
+++ b/src/evaluationUtils/printAndRethrowError.ts
@@ -1,5 +1,5 @@
 import { StackTraceEntry } from '../expressions/debug/StackTraceEntry';
-import { SourceRange } from '../expressions/debug/StackTraceGenerator';
+import { PositionedError } from './PositionedError';
 
 function getNumberStringLength(i: number) {
 	return Math.floor(Math.log10(i)) + 1;
@@ -57,13 +57,4 @@ export function printAndRethrowError(selector: string, error: Error | StackTrace
 	// tslint:disable-next-line:no-console We do want to write these to error.
 	console.error(errorMessage);
 	throw newError;
-}
-
-class PositionedError extends Error {
-	public readonly position: SourceRange;
-
-	constructor(message: string, position: SourceRange) {
-		super(message);
-		this.position = position;
-	}
 }

--- a/test/specs/parsing/debug/stackTrace.tests.ts
+++ b/test/specs/parsing/debug/stackTrace.tests.ts
@@ -150,4 +150,27 @@ Error: XPST0008, The variable map is not in scope.
   at <pathExpr>:9:1 - 9:12`
 		);
 	});
+
+	it('contains the correct location of the error in the code', () => {
+		const errorLine = '$map("key")';
+		const position = {
+			end: {
+				column: 12,
+				line: 7,
+				offset: 41
+			},
+			start: {
+				column: 1,
+				line: 7,
+				offset: 30
+			}
+		};
+		try {
+			const lines = Array(10).fill('(::)');
+			lines[6] = errorLine;
+			evaluateXPath(lines.join('\n'), null, null, null, null, { debug: true });
+		} catch (error) {
+			chai.assert.deepEqual(error.position, position);
+		}
+	});
 });


### PR DESCRIPTION
This should not break anything existing, while giving extra information about the position the error occurred at in the code.