### PR TITLE
Allow a namespace resolver to be used instead of a callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # fontoxpath [![Build Status](https://travis-ci.org/FontoXML/fontoxpath.svg?branch=master)](https://travis-ci.org/FontoXML/fontoxpath) [![devDependency Status](https://david-dm.org/FontoXML/fontoxpath/dev-status.svg)](https://david-dm.org/FontoXML/fontoxpath#info=devDependencies) [![NPM version](https://badge.fury.io/js/fontoxpath.svg)](http://badge.fury.io/js/fontoxpath) [![Greenkeeper badge](https://badges.greenkeeper.io/FontoXML/fontoxpath.svg)](https://greenkeeper.io/) [![install size](https://packagephobia.now.sh/badge?p=fontoxpath)](https://packagephobia.now.sh/result?p=fontoxpath) [![Coverage Status](https://coveralls.io/repos/github/FontoXML/fontoxpath/badge.svg?branch=master)](https://coveralls.io/github/FontoXML/fontoxpath?branch=master)
 
-A minimalistic [XPath 3.1](https://www.w3.org/TR/xpath-31/) and [XQuery 3.1](https://www.w3.org/TR/xquery-31/) engine for (XML) nodes with [XQuery Update Facility 3.0](https://www.w3.org/TR/xquery-update-30/#id-update-primitives) support.
+A minimalistic [XPath 3.1](https://www.w3.org/TR/xpath-31/) and [XQuery
+3.1](https://www.w3.org/TR/xquery-31/) engine for (XML) nodes with [XQuery Update Facility
+3.0](https://www.w3.org/TR/xquery-update-30/#id-update-primitives) support.
 
 [Demo page](https://xpath.playground.fontoxml.com)
 
@@ -28,15 +30,26 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
 ```
 
 * `xpathExpression` `<String>` The query to evaluate.
-* `contextNode` `<Node>` The node in which context the `xpathExpression` will be evaluated. Defaults to `null`.
-* `domFacade` `<IDomFacade>` An [IDomFacade](src/domFacade/IDomFacade.ts) implementation which will be used for querying the DOM. Defaults to an implementation which uses properties and methods on the `contextNode` as described in the [DOM spec](https://dom.spec.whatwg.org/).
-* `variables` `<Object>` The properties of `variables` are available variables within the `xpathExpression`. Defaults to an empty `Object`.
-* `returnType` `<number>` Determines the type of the result. Defaults to `evaluateXPath.ANY_TYPE`. Possible values:
-  * `evaluateXPath.ANY_TYPE` Returns the result of the query, can be anything depending on the query. Note that the return type is determined dynamically, not statically: XPaths returning empty sequences will return empty arrays and not null, like one might expect.
+* `contextNode` `<Node>` The node in which context the `xpathExpression` will be evaluated. Defaults
+  to `null`.
+* `domFacade` `<IDomFacade>` An [IDomFacade](src/domFacade/IDomFacade.ts) implementation which will
+  be used for querying the DOM. Defaults to an implementation which uses properties and methods on
+  the `contextNode` as described in the [DOM spec](https://dom.spec.whatwg.org/).
+* `variables` `<Object>` The properties of `variables` are available variables within the
+  `xpathExpression`. Defaults to an empty `Object`.
+* `returnType` `<number>` Determines the type of the result. Defaults to
+  `evaluateXPath.ANY_TYPE`. Possible values:
+  * `evaluateXPath.ANY_TYPE` Returns the result of the query, can be anything depending on the
+    query. Note that the return type is determined dynamically, not statically: XPaths returning
+    empty sequences will return empty arrays and not null, like one might expect.
   * `evaluateXPath.NUMBER_TYPE` Resolve to a `number`, like count((1,2,3)) resolves to 3.
-  * `evaluateXPath.STRING_TYPE` Resolve to a `string`, like //someElement[1] resolves to the text content of the first someElement.
-  * `evaluateXPath.BOOLEAN_TYPE` Resolves to a `boolean` true or false, uses the effective boolean value to determine the result. count(1) resolves to true, count(()) resolves to false.
-  * `evaluateXPath.NODES_TYPE` Resolve to all nodes `Node[]` the XPath resolves to. Returns nodes in the order the XPath would. Meaning (//a, //b) resolves to all A nodes, followed by all B nodes. //*[self::a or self::b] resolves to A and B nodes in document order.
+  * `evaluateXPath.STRING_TYPE` Resolve to a `string`, like //someElement[1] resolves to the text
+    content of the first someElement.
+  * `evaluateXPath.BOOLEAN_TYPE` Resolves to a `boolean` true or false, uses the effective boolean
+    value to determine the result. count(1) resolves to true, count(()) resolves to false.
+  * `evaluateXPath.NODES_TYPE` Resolve to all nodes `Node[]` the XPath resolves to. Returns nodes in
+    the order the XPath would. Meaning (//a, //b) resolves to all A nodes, followed by all B
+    nodes. //*[self::a or self::b] resolves to A and B nodes in document order.
   * `evaluateXPath.FIRST_NODE_TYPE` Resolves to the first `Node` node.NODES_TYPE would have resolved to.
   * `evaluateXPath.STRINGS_TYPE` Resolve to an array of strings `string[]`.
   * `evaluateXPath.MAP_TYPE` Resolve to an `Object`, as a map.
@@ -44,11 +57,19 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
   * `evaluateXPath.ASYNC_ITERATOR_TYPE`
   * `evaluateXPath.NUMBERS_TYPE` Resolve to an array of numbers `number[]`.
 * `options` `<Object>` Options used to modify the behavior. The following options are available:
-  * `namespaceResolver` `<function(string):string?>`
-  * `nodesFactory` `INodesFactory` A [INodesFactory](src/nodesFactory/INodesFactory.ts) implementation which will be used for creating nodes.
-  * `language` `string` The query language to use. Defaults to `evaluateXPath.XPATH_3_1_LANGUAGE`. Possible values:
-    * `evaluateXPath.XPATH_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XPath spec](https://www.w3.org/TR/xpath-31/).
-    * `evaluateXPath.XQUERY_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XQuery spec](https://www.w3.org/TR/xquery-31/).
+  * `namespaceResolver` Either a function that accepts a prefix string and returns null or
+    undefined, or an object that keys prefixes to namespace URIs. The Object is expected to be
+    frozen. For performance, it is better to use an object since FontoXPath has an easier time
+    figuring out whether an earlier compiled selector can be re-used or whether it needs to be
+    recompiled.
+  * `nodesFactory` `INodesFactory` A [INodesFactory](src/nodesFactory/INodesFactory.ts)
+    implementation which will be used for creating nodes.
+  * `language` `string` The query language to use. Defaults to
+    `evaluateXPath.XPATH_3_1_LANGUAGE`. Possible values:
+    * `evaluateXPath.XPATH_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XPath
+      spec](https://www.w3.org/TR/xpath-31/).
+    * `evaluateXPath.XQUERY_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XQuery
+      spec](https://www.w3.org/TR/xquery-31/).
   * `moduleImports` `<Object<string, string>`
   * `debug` `<boolean>` If a debug trace should be tracked, see (debugging)[#] for more information.
 
@@ -102,15 +123,25 @@ Error: FORG0003: The argument passed to fn:zero-or-one contained more than one i
 
 ### Modifying XML
 
-Note: the use of XQuery Update Facility 3.0 is in preview and subject to change.
-
-To modify XML you can use [XQuery Update Facility 3.0](https://www.w3.org/TR/xquery-update-30/) as following
+To modify XML you can use [XQuery Update Facility 3.0](https://www.w3.org/TR/xquery-update-30/) as
+following
 
 ```js
 evaluateUpdatingExpression(xpathExpression, contextNode, domFacade, variables, options);
 ```
 
-The arguments are the same as `evaluateXPath`. This returns a `Promise<Object>`, the object has a `xdmValue` and `pendingUpdateList`. The `xdmValue` is the result of query as if it was run using `evaluateXPath` with `evaluateXPath.ANY_TYPE` as `returnType`. The `pendingUpdateList` is an `<Object[]>` in which each entry represents an [update primitive](https://www.w3.org/TR/xquery-update-30/#id-update-primitives) where the `type` identifies the update primitive.
+or
+
+```js
+evaluateUpdatingExpressionSync(xpathExpression, contextNode, domFacade, variables, options);
+```
+
+The arguments are the same as `evaluateXPath`. This returns a `Promise<Object>`, or an object
+directly. The object has a `xdmValue` and `pendingUpdateList`. The `xdmValue` is the result of query
+as if it was run using `evaluateXPath` with `evaluateXPath.ANY_TYPE` as `returnType`. The
+`pendingUpdateList` is an `<Object[]>` in which each entry represents an [update
+primitive](https://www.w3.org/TR/xquery-update-30/#id-update-primitives) where the `type` identifies
+the update primitive.
 
 The pending update list can be executed using
 
@@ -120,8 +151,12 @@ executePendingUpdateList(pendingUpdateList, domFacade, nodesFactory, documentWri
 
 * `pendingUpdateList` `<Object[]>` The pending update list returned by `evaluateUpdatingExpression`.
 * `domFacade` `<IDomFacade>` See `evaluateXPath`. The default will use nodes from the `pendingUpdateList`.
-* `nodesFactory` `INodesFactory` A [INodesFactory](src/nodesFactory/INodesFactory.ts) implementation which will be used for creating nodes. Defaults to an implementation which uses properties and methods of nodes from the `pendingUpdateList`.
-* `documentWriter` `<IDocumentWriter>` An [IDocumentWriter](src/documentWriter/IDocumePntWriter.ts) implementation which will be used for modifying a DOM. Defaults to an implementation which uses properties and methods of nodes from the `pendingUpdateList`.
+* `nodesFactory` `INodesFactory` A [INodesFactory](src/nodesFactory/INodesFactory.ts) implementation
+  which will be used for creating nodes. Defaults to an implementation which uses properties and
+  methods of nodes from the `pendingUpdateList`.
+* `documentWriter` `<IDocumentWriter>` An [IDocumentWriter](src/documentWriter/IDocumePntWriter.ts)
+  implementation which will be used for modifying a DOM. Defaults to an implementation which uses
+  properties and methods of nodes from the `pendingUpdateList`.
 
 ### Example
 
@@ -142,7 +177,9 @@ evaluateUpdatingExpression('replace node /xml with <foo/>', documentNode)
 
 ### Pre compilation
 
-Precompile an XPath expression for future use. This uses a webworker to populate an IndexedDB database so that the XPath is available for future use. This is a no-op on systems without indexedDB.
+Precompile an XPath expression for future use. This uses a webworker to populate an IndexedDB
+database so that the XPath is available for future use. This is a no-op on systems without
+indexedDB.
 
 ```js
 precompileXPath(xpathExpression);
@@ -189,8 +226,8 @@ mode](https://www.w3.org/TR/xpath-31/#id-backwards-compatibility) turned off.
 Not all [XPath 3.1 functions](https://www.w3.org/TR/xpath-functions-31/) are implemented yet. We
 accept pull requests for missing features.
 
-The following features are unavailable at this moment, but will be implemented at some point in time ([and even
-sooner if you can help!](./CONTRIBUTING.md)):
+The following features are unavailable at this moment, but will be implemented at some point in time
+([and even sooner if you can help!](./CONTRIBUTING.md)):
 
 * Some DateTime related functions
 * Collation related functions (`fn:compare#3`)

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -66,8 +66,9 @@ export default async function evaluateUpdatingExpression(
 				disableCache: !!options['disableCache']
 			}
 		);
-		dynamicContext = context.dynamicContext;
-		executionParameters = context.executionParameters;
+		const dynamicContextAndExecutionParameters = context.buildDynamicContextAndExecutionParameters();
+		dynamicContext = dynamicContextAndExecutionParameters.dynamicContext;
+		executionParameters = dynamicContextAndExecutionParameters.executionParameters;
 		expression = context.expression;
 	} catch (error) {
 		printAndRethrowError(updateScript, error);
@@ -78,7 +79,7 @@ export default async function evaluateUpdatingExpression(
 		// scripts. Copy/modify/transform expressions are examples of updating expressions that are
 		// not really updating
 		const resultItems = [];
-		let it = evaluateXPathToAsyncIterator(updateScript, contextItem, domFacade, variables, {
+		const it = evaluateXPathToAsyncIterator(updateScript, contextItem, domFacade, variables, {
 			...options,
 			language: Language.XQUERY_UPDATE_3_1_LANGUAGE
 		});

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -56,8 +56,9 @@ export default function evaluateUpdatingExpressionSync<
 				disableCache: !!options['disableCache']
 			}
 		);
-		dynamicContext = context.dynamicContext;
-		executionParameters = context.executionParameters;
+		const dynamicContextAndExecutionParameters = context.buildDynamicContextAndExecutionParameters();
+		dynamicContext = dynamicContextAndExecutionParameters.dynamicContext;
+		executionParameters = dynamicContextAndExecutionParameters.executionParameters;
 		expression = context.expression;
 	} catch (error) {
 		printAndRethrowError(updateScript, error);

--- a/src/expressions/ExecutionSpecificStaticContext.ts
+++ b/src/expressions/ExecutionSpecificStaticContext.ts
@@ -42,7 +42,6 @@ export default class ExecutionSpecificStaticContext implements IContext {
 		[variable: string]: { name: string };
 	};
 	private _variableBindingByName: { [variableName: string]: string };
-	private _variableValueByName: any;
 
 	constructor(namespaceResolver: (prefix: string) => string | null, variableByName: object) {
 		this._namespaceResolver = namespaceResolver;
@@ -60,8 +59,6 @@ export default class ExecutionSpecificStaticContext implements IContext {
 		this._referredVariableByName = Object.create(null);
 		this._referredNamespaceByName = Object.create(null);
 
-		this._variableValueByName = variableByName;
-
 		/**
 		 * This flag will be set to true if this EvaluationContext was used while statically
 		 * compiling a Expression
@@ -69,15 +66,23 @@ export default class ExecutionSpecificStaticContext implements IContext {
 		this.executionContextWasRequired = false;
 	}
 
-	public getReferredNamespaces(): { namespaceURI: string; prefix: string }[] {
+	public getReferredNamespaces(): { namespaceURI: string; prefix: string }[] | null {
 		return Object.values(this._referredNamespaceByName);
 	}
 
-	public getReferredVariables(): { name: string }[] {
-		return Object.values(this._referredVariableByName);
+	public getReferredVariables(): { name: string }[] | null {
+		const values = Object.values(this._referredVariableByName);
+		if (values.length === 0) {
+			return null;
+		}
+		return values;
 	}
 
-	public lookupFunction(namespaceURI, localName, arity): FunctionProperties {
+	public lookupFunction(
+		namespaceURI: string,
+		localName: string,
+		arity: number
+	): FunctionProperties {
 		// It is impossible to inject functions at execution time, so we can always return a globally defined one.
 		return getFunctionByArity(namespaceURI, localName, arity);
 	}

--- a/src/expressions/debug/StackTraceGenerator.ts
+++ b/src/expressions/debug/StackTraceGenerator.ts
@@ -9,11 +9,13 @@ import { IterationHint } from '../util/iterators';
 import { StackTraceEntry } from './StackTraceEntry';
 
 export default class StackTraceGenerator extends PossiblyUpdatingExpression {
-	private _innerExpressionType: string;
-	private _location: SourceRange;
+	private readonly _innerExpression: Expression;
+	private readonly _innerExpressionType: string;
+	private readonly _location: SourceRange;
 
 	constructor(location: SourceRange, innerExpressionType: string, innerExpression: Expression) {
 		super(innerExpression.specificity, [innerExpression], {});
+		this._innerExpression = innerExpression;
 
 		this._innerExpressionType = innerExpressionType;
 
@@ -29,6 +31,10 @@ export default class StackTraceGenerator extends PossiblyUpdatingExpression {
 				offset: location['start']['offset']
 			}
 		};
+	}
+
+	public getBucket() {
+		return this._innerExpression.getBucket();
 	}
 
 	public performFunctionalEvaluation(

--- a/test/specs/parsing/xquery/VariableDeclaration.tests.ts
+++ b/test/specs/parsing/xquery/VariableDeclaration.tests.ts
@@ -70,7 +70,7 @@ describe('VariableDeclaration', () => {
 	it('allows external variables with defaults', () => {
 		chai.assert.equal(
 			evaluateXPathToString(
-				`declare variable $nx as xs:integer external := 12; 
+				`declare variable $nx as xs:integer external := 12;
                 <out>{$nx}</out>`,
 				documentNode,
 				undefined,
@@ -85,7 +85,7 @@ describe('VariableDeclaration', () => {
 		// We are checking that the var is not cached from the previous test
 		chai.assert.equal(
 			evaluateXPathToString(
-				`declare variable $nx as xs:integer external := 12; 
+				`declare variable $nx as xs:integer external := 12;
                 <out>{$nx}</out>`,
 				documentNode,
 				undefined,
@@ -99,7 +99,7 @@ describe('VariableDeclaration', () => {
 	it('allows external variables with defaults and external parameters', () => {
 		chai.assert.equal(
 			evaluateXPathToString(
-				`declare variable $nxa as xs:integer external := 10; 
+				`declare variable $nxa as xs:integer external := 10;
                 <out>{$nxa}</out>`,
 				documentNode,
 				undefined,
@@ -130,7 +130,7 @@ describe('VariableDeclaration', () => {
 			evaluateXPathToNumber(
 				`
 				declare variable $x := 1;
-				$x	
+				$x
 			`,
 				documentNode,
 				null,
@@ -145,7 +145,7 @@ describe('VariableDeclaration', () => {
 			evaluateXPathToNumber(
 				`
 					declare variable $x := 1;
-					$x	
+					$x
 				`,
 				documentNode,
 				null,


### PR DESCRIPTION
The object can increase performance if you run XPaths like `evaluateXPathToBoolean('self::p', node)`
extremely frequently. This tries to use cached expressions and buckets to short-cut executions, but
determining whether a selector is re-usable for the same namespace config slowed it down.