### PR TITLE
Fix debugging documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
     * `evaluateXPath.XPATH_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XPath spec](https://www.w3.org/TR/xpath-31/).
     * `evaluateXPath.XQUERY_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XQuery spec](https://www.w3.org/TR/xquery-31/).
   * `moduleImports` `<Object<string, string>`
-  * `debug` `<boolean>` If a debug trace should be tracked, see (debugging)[#] for more information.
+  * `debug` `<boolean>` If a debug trace should be tracked, see [debugging](#debugging) for more information.
 
 ### Example
 
@@ -86,7 +86,7 @@ if (true()) then
   zero-or-one((1, 2))
 else
   (1, 2, 3)
-`, null, null, null, {debugMode: true});
+`, null, null, null, {debug: true});
 
 // Throws:
 1: if (true()) then


### PR DESCRIPTION
* Use the correct name for the `debug` option.
* Fix the documentation link.