### PR TITLE
Dev 5329 output context in x query traces used in hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
     * `evaluateXPath.XQUERY_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XQuery spec](https://www.w3.org/TR/xquery-31/).
   * `moduleImports` `<Object<string, string>`
   * `debug` `<boolean>` If a debug trace should be tracked, see [debugging](#debugging) for more information.
-  * `logOutput` `<function(string):void>` Log additional console statements for the trace function.
+  * `logger` `<Object>` Object with functions used to override the standard logger.
+    * `trace: <function(string):void>` The logger for the `trace()` function. The argument is the string of the original message.
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
     * `evaluateXPath.XQUERY_3_1_LANGUAGE` Evaluate `xpathExpression` according the [XQuery spec](https://www.w3.org/TR/xquery-31/).
   * `moduleImports` `<Object<string, string>`
   * `debug` `<boolean>` If a debug trace should be tracked, see [debugging](#debugging) for more information.
+  * `logOutput` `<function(string):void>` Log additional console statements for the trace function.
 
 ### Example
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,12 +1,15 @@
 <html>
 	<head>
 		<title>fontoxpath</title>
-		<meta charset="utf-8">
-		<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css">
+		<meta charset="utf-8" />
+		<link
+			rel="stylesheet"
+			href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/default.min.css"
+		/>
 		<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
 		<script src="./main.js" type="module"></script>
 		<style>
-		 	#xmlFile * {
+			#xmlFile * {
 				all: initial;
 				display: block;
 				margin: 5px 5px 5px 5px;
@@ -22,15 +25,24 @@
 		<div>
 			<h4>Edit the XML here</h4>
 			<sub>Note: Highlighting will only update on page reload.</sub>
-			<pre id="xmlSource" contentEditable="true"> </pre>
+			<pre id="xmlSource" contenteditable="true"></pre>
 			<h4>Edit the XPath here:</h4>
-			<label><input id="allowXQuery" type="checkbox"/>XQuery</label>
-			<label><input id="allowXQueryUpdateFacility" type="checkbox"/>XQuery Update Facility</label>
-			<pre type="text" contentEditable="true" id="xpathField" value="//*" style="min-height:100px"></pre>
+			<label><input id="allowXQuery" type="checkbox" />XQuery</label>
+			<label
+				><input id="allowXQueryUpdateFacility" type="checkbox" />XQuery Update
+				Facility</label
+			>
+			<pre
+				type="text"
+				contenteditable="true"
+				id="xpathField"
+				value="//*"
+				style="min-height:100px"
+			></pre>
 			<h4>The bucket for this selector</h4>
 			<pre id="bucketField"></pre>
 		</div>
-		<hr>
+		<hr />
 		<div>
 			<pre id="log"></pre>
 			<h4>Result, as text</h4>
@@ -41,6 +53,8 @@
 			<pre id="astJsonMl"></pre>
 			<h4>AST, as XML</h4>
 			<pre id="astXml"></pre>
+			<h4>Trace Output</h4>
+			<pre id="traceOutput"></pre>
 		</div>
 	</body>
 </html>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -122,7 +122,10 @@ function jsonXmlReplacer(_key: string, value: any): any {
 async function runUpdatingXQuery(script: string) {
 	const result = await fontoxpath.evaluateUpdatingExpression(script, xmlDoc, null, null, {
 		debug: true,
-		disableCache: true
+		disableCache: true,
+		logOutput: m => {
+			console.log(m);
+		}
 	});
 
 	resultText.innerText = JSON.stringify(result, jsonXmlReplacer, '  ');
@@ -137,7 +140,10 @@ async function runNormalXPath(script: string, asXQuery: boolean) {
 		disableCache: true,
 		language: asXQuery
 			? fontoxpath.evaluateXPath.XQUERY_3_1_LANGUAGE
-			: fontoxpath.evaluateXPath.XPATH_3_1_LANGUAGE
+			: fontoxpath.evaluateXPath.XPATH_3_1_LANGUAGE,
+		logOutput: m => {
+			console.log(m);
+		}
 	});
 
 	for (let item = await it.next(); !item.done; item = await it.next()) {

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -15,6 +15,7 @@ const resultText = document.getElementById('resultText');
 const updateResult = document.getElementById('updateResult');
 const xmlSource = document.getElementById('xmlSource');
 const xpathField = document.getElementById('xpathField');
+const traceOutput = document.getElementById('traceOutput');
 
 const domParser = new DOMParser();
 
@@ -123,8 +124,11 @@ async function runUpdatingXQuery(script: string) {
 	const result = await fontoxpath.evaluateUpdatingExpression(script, xmlDoc, null, null, {
 		debug: true,
 		disableCache: true,
-		logOutput: m => {
-			console.log(m);
+		logger: {
+			trace: m => {
+				traceOutput.textContent = m;
+				console.log(m);
+			}
 		}
 	});
 
@@ -141,8 +145,11 @@ async function runNormalXPath(script: string, asXQuery: boolean) {
 		language: asXQuery
 			? fontoxpath.evaluateXPath.XQUERY_3_1_LANGUAGE
 			: fontoxpath.evaluateXPath.XPATH_3_1_LANGUAGE,
-		logOutput: m => {
-			console.log(m);
+		logger: {
+			trace: m => {
+				traceOutput.textContent = m;
+				console.log(m);
+			}
 		}
 	});
 
@@ -159,6 +166,7 @@ async function rerunXPath() {
 	log.innerText = '';
 	resultText.innerText = '';
 	updateResult.innerText = '';
+	traceOutput.innerText = '';
 
 	const xpath = xpathField.innerText;
 

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -1,6 +1,6 @@
 import IDocumentWriter from './documentWriter/IDocumentWriter';
 import IDomFacade from './domFacade/IDomFacade';
-import { Language } from './evaluateXPath';
+import { Language, Logger } from './evaluateXPath';
 import evaluateXPathToAsyncIterator from './evaluateXPathToAsyncIterator';
 import buildContext from './evaluationUtils/buildContext';
 import convertUpdateResultToTransferable from './evaluationUtils/convertUpdateResultToTransferable';
@@ -21,7 +21,7 @@ export type UpdatingOptions = {
 	debug?: boolean;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
-	logOutput?: (message: string) => void;
+	logger?: Logger;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -21,6 +21,7 @@ export type UpdatingOptions = {
 	debug?: boolean;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
+	logOutput?: (message: string) => void;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -16,9 +16,10 @@ import { Node } from './types/Types';
 export type Options = {
 	currentContext?: any;
 	debug?: boolean;
-	documentWriter?: IDocumentWriter;
 	disableCache?: boolean;
+	documentWriter?: IDocumentWriter;
 	language?: Language;
+	logOutput?: (message: string) => void;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -13,13 +13,20 @@ import { Node } from './types/Types';
 /**
  * @public
  */
+export type Logger = {
+	trace: (message: string) => void;
+};
+
+/**
+ * @public
+ */
 export type Options = {
 	currentContext?: any;
 	debug?: boolean;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
 	language?: Language;
-	logOutput?: (message: string) => void;
+	logger?: Logger;
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -68,7 +68,7 @@ export default function buildEvaluationContext(
 	if (externalOptions) {
 		internalOptions = {
 			// tslint:disable-next-line:no-console
-			logOutput: externalOptions['logOutput'] || console.log.bind(console),
+			logger: externalOptions['logger'] || { trace: console.log.bind(console) },
 			moduleImports: externalOptions['moduleImports'],
 			namespaceResolver: externalOptions['namespaceResolver'],
 			nodesFactory: externalOptions['nodesFactory']
@@ -76,7 +76,7 @@ export default function buildEvaluationContext(
 	} else {
 		internalOptions = {
 			// tslint:disable-next-line:no-console
-			logOutput: console.log.bind(console),
+			logger: { trace: console.log.bind(console) },
 			moduleImports: {},
 			namespaceResolver: null,
 			nodesFactory: null
@@ -142,7 +142,7 @@ export default function buildEvaluationContext(
 		nodesFactory,
 		documentWriter,
 		externalOptions['currentContext'],
-		internalOptions.logOutput
+		internalOptions.logger
 	);
 
 	return {

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -67,12 +67,20 @@ export default function buildEvaluationContext(
 	let internalOptions: Options;
 	if (externalOptions) {
 		internalOptions = {
+			// tslint:disable-next-line:no-console
+			logOutput: externalOptions['logOutput'] || console.log.bind(console),
 			moduleImports: externalOptions['moduleImports'],
 			namespaceResolver: externalOptions['namespaceResolver'],
 			nodesFactory: externalOptions['nodesFactory']
 		};
 	} else {
-		internalOptions = { namespaceResolver: null, nodesFactory: null, moduleImports: {} };
+		internalOptions = {
+			// tslint:disable-next-line:no-console
+			logOutput: console.log.bind(console),
+			moduleImports: {},
+			namespaceResolver: null,
+			nodesFactory: null
+		};
 	}
 	const wrappedDomFacade: IWrappingDomFacade = new DomFacade(
 		domFacade === null ? new ExternalDomFacade() : domFacade
@@ -133,7 +141,8 @@ export default function buildEvaluationContext(
 		wrappedDomFacade,
 		nodesFactory,
 		documentWriter,
-		externalOptions['currentContext']
+		externalOptions['currentContext'],
+		internalOptions.logOutput
 	);
 
 	return {

--- a/src/expressions/ExecutionParameters.ts
+++ b/src/expressions/ExecutionParameters.ts
@@ -1,6 +1,7 @@
 import IDocumentWriter from '../documentWriter/IDocumentWriter';
 import IWrappingDomFacade from '../domFacade/IWrappingDomFacade';
 import INodesFactory from '../nodesFactory/INodesFactory';
+import { Logger } from '../evaluateXPath';
 
 export default class ExecutionParameters {
 	constructor(
@@ -8,6 +9,6 @@ export default class ExecutionParameters {
 		public readonly nodesFactory: INodesFactory,
 		public readonly documentWriter: IDocumentWriter,
 		public readonly currentContext: any,
-		public readonly logOutput?: (message: string) => void
+		public readonly logger?: Logger
 	) {}
 }

--- a/src/expressions/ExecutionParameters.ts
+++ b/src/expressions/ExecutionParameters.ts
@@ -7,6 +7,7 @@ export default class ExecutionParameters {
 		public readonly domFacade: IWrappingDomFacade,
 		public readonly nodesFactory: INodesFactory,
 		public readonly documentWriter: IDocumentWriter,
-		public readonly currentContext: any
+		public readonly currentContext: any,
+		public readonly logOutput?: (message: string) => void
 	) {}
 }

--- a/src/expressions/functions/builtInFunctions.debugging.ts
+++ b/src/expressions/functions/builtInFunctions.debugging.ts
@@ -6,22 +6,32 @@ import { FUNCTIONS_NAMESPACE_URI } from '../staticallyKnownNamespaces';
 
 import FunctionDefinitionType from './FunctionDefinitionType';
 
-const fnTrace: FunctionDefinitionType = function(
+const fnTrace: FunctionDefinitionType = (
 	_dynamicContext,
 	executionParameters,
 	_staticContext,
 	arg,
 	label
-) {
+) => {
 	return arg.mapAll(allItems => {
 		const argumentAsStrings = atomize(sequenceFactory.create(allItems), executionParameters)
 			.map(value => castToType(value, 'xs:string'))
 			.getAllValues();
 
-		console.log.apply(
-			console,
-			label ? [argumentAsStrings, label.first().value] : [argumentAsStrings]
-		);
+		let newMessage = '';
+		for (let i = 0; i < argumentAsStrings.length; i++) {
+			newMessage +=
+				'{type: ' +
+				argumentAsStrings[i].type +
+				', value: ' +
+				argumentAsStrings[i].value +
+				'}\n';
+		}
+		if (label !== undefined) {
+			newMessage += label.first().value;
+		}
+		executionParameters.logOutput(newMessage);
+
 		// Note: rewrap here to prevent double iterations of the input
 		return sequenceFactory.create(allItems);
 	});
@@ -30,18 +40,18 @@ const fnTrace: FunctionDefinitionType = function(
 export default {
 	declarations: [
 		{
-			namespaceURI: FUNCTIONS_NAMESPACE_URI,
-			localName: 'trace',
 			argumentTypes: ['item()*'],
-			returnType: 'item()*',
-			callFunction: fnTrace
+			callFunction: fnTrace,
+			localName: 'trace',
+			namespaceURI: FUNCTIONS_NAMESPACE_URI,
+			returnType: 'item()*'
 		},
 		{
-			namespaceURI: FUNCTIONS_NAMESPACE_URI,
-			localName: 'trace',
 			argumentTypes: ['item()*', 'xs:string'],
-			returnType: 'item()*',
-			callFunction: fnTrace
+			callFunction: fnTrace,
+			localName: 'trace',
+			namespaceURI: FUNCTIONS_NAMESPACE_URI,
+			returnType: 'item()*'
 		}
 	]
 };

--- a/src/expressions/functions/builtInFunctions.debugging.ts
+++ b/src/expressions/functions/builtInFunctions.debugging.ts
@@ -30,9 +30,8 @@ const fnTrace: FunctionDefinitionType = (
 		if (label !== undefined) {
 			newMessage += label.first().value;
 		}
-		executionParameters.logOutput(newMessage);
+		executionParameters.logger.trace(newMessage);
 
-		// Note: rewrap here to prevent double iterations of the input
 		return sequenceFactory.create(allItems);
 	});
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import ExternalDomFacade from './domFacade/ExternalDomFacade';
 import IDomFacade from './domFacade/IDomFacade';
 import evaluateUpdatingExpression, { UpdatingOptions } from './evaluateUpdatingExpression';
 import evaluateUpdatingExpressionSync from './evaluateUpdatingExpressionSync';
-import evaluateXPath, { Language, Options, EvaluateXPath } from './evaluateXPath';
+import evaluateXPath, { Language, Options, EvaluateXPath, Logger } from './evaluateXPath';
 import evaluateXPathToArray from './evaluateXPathToArray';
 import evaluateXPathToAsyncIterator from './evaluateXPathToAsyncIterator';
 import evaluateXPathToBoolean from './evaluateXPathToBoolean';
@@ -138,6 +138,7 @@ export {
 	INodesFactory,
 	IReturnTypes,
 	Language,
+	Logger,
 	Node,
 	Options,
 	ProcessingInstruction,


### PR DESCRIPTION
Added an option `logOutput` `<function(string):void>` to output additional console statement when using the `trace` function. The readme has been updated accordingly.