### PR TITLE
Only throw error in debug mode, do not also output to STDERR

### DIFF
--- a/src/evaluationUtils/printAndRethrowError.ts
+++ b/src/evaluationUtils/printAndRethrowError.ts
@@ -53,8 +53,5 @@ export function printAndRethrowError(selector: string, error: Error | StackTrace
 
 	const stackTrace = stackEntry.makeStackTrace().join('\n');
 	const errorMessage = lines.join('\n') + '\n\n' + stackTrace;
-	const newError = new PositionedError(errorMessage, errorLocation);
-	// tslint:disable-next-line:no-console We do want to write these to error.
-	console.error(errorMessage);
-	throw newError;
+	throw new PositionedError(errorMessage, errorLocation);
 }


### PR DESCRIPTION
Logging an error to STDERR is the responsibility of the consumer of fontoxpath. No need to `console.error` here.