### PR TITLE
Correctly cache similar selectors

### DIFF
--- a/src/parsing/compiledExpressionCache.ts
+++ b/src/parsing/compiledExpressionCache.ts
@@ -100,11 +100,9 @@ export function getStaticCompilationResultFromCache(
 	const languageKey = generateLanguageKey(language, debug);
 	const cachesForLanguage = cachesForExpression[languageKey];
 	if (!cachesForLanguage) {
-		const halfCompiledExpressionFromCache = getAnyStaticCompilationResultFromCache(
-			selectorString,
-			language,
-			debug
-		);
+		const halfCompiledExpressionFromCache =
+			halfCompiledExpressionCache[selectorString] &&
+			halfCompiledExpressionCache[selectorString][languageKey];
 		if (halfCompiledExpressionFromCache) {
 			return {
 				expression: halfCompiledExpressionFromCache,
@@ -126,11 +124,9 @@ export function getStaticCompilationResultFromCache(
 	);
 
 	if (!cacheWithCorrectContext) {
-		const halfCompiledExpressionFromCache = getAnyStaticCompilationResultFromCache(
-			selectorString,
-			language,
-			debug
-		);
+		const halfCompiledExpressionFromCache =
+			halfCompiledExpressionCache[selectorString] &&
+			halfCompiledExpressionCache[selectorString][languageKey];
 		if (halfCompiledExpressionFromCache) {
 			return {
 				expression: halfCompiledExpressionFromCache,

--- a/test/specs/parsing/evaluateXPath.tests.ts
+++ b/test/specs/parsing/evaluateXPath.tests.ts
@@ -13,7 +13,8 @@ import {
 	evaluateXPathToNumber,
 	evaluateXPathToNumbers,
 	evaluateXPathToString,
-	evaluateXPathToStrings
+	evaluateXPathToStrings,
+	getBucketForSelector
 } from 'fontoxpath';
 
 import jsonMlMapper from 'test-helpers/jsonMlMapper';
@@ -355,6 +356,33 @@ describe('evaluateXPath', () => {
 					'xs:QName("something-without-a-prefix") => namespace-uri-from-QName() eq "http://example.com/ns"',
 					ele
 				)
+			);
+		});
+
+		it('can correctly cache everything when using the default resolver', () => {
+			const nameSpaceDocument = new slimdom.Document();
+			const namespaceElement = nameSpaceDocument.createElementNS('http://test.com', 'name');
+			namespaceElement.textContent = 'name1';
+			nameSpaceDocument.appendChild(namespaceElement);
+
+			chai.assert.equal(evaluateXPathToString('/name/text()', nameSpaceDocument), 'name1');
+
+			const slimdomDocument = new slimdom.Document();
+			const nameElement = slimdomDocument.createElement('name');
+			nameElement.textContent = 'name2';
+			slimdomDocument.appendChild(nameElement);
+			chai.assert.equal(evaluateXPathToString('/name/text()', slimdomDocument), 'name2');
+		});
+
+		it('can correctly cache everything when first determining buckets', () => {
+			getBucketForSelector('/name/text() (:from-this-test:)');
+			const slimdomDocument = new slimdom.Document();
+			const nameElement = slimdomDocument.createElement('name');
+			nameElement.textContent = 'name';
+			slimdomDocument.appendChild(nameElement);
+			chai.assert.equal(
+				evaluateXPathToString('/name/text() (:from-this-test:)', slimdomDocument),
+				'name'
 			);
 		});
 


### PR DESCRIPTION
Do not read from the actual cache when only intending to read from the half-compiled cache

Fixes #222 