### PR TITLE
Pass the 'element' bucket for descendants if we only want elements

### DIFF
--- a/src/domFacade/ExternalDomFacade.ts
+++ b/src/domFacade/ExternalDomFacade.ts
@@ -1,13 +1,18 @@
 import { Attr, CharacterData, Node } from '../types/Types';
 import { NODE_TYPES } from './ConcreteNode';
 import IDomFacade from './IDomFacade';
+import { getBucketsForNode } from '../getBuckets';
 
 export default class ExternalDomFacade implements IDomFacade {
-	public ['getAllAttributes'](node: Node): Attr[] {
+	public ['getAllAttributes'](node: Node, bucket: string | null = null): Attr[] {
 		if (node.nodeType !== NODE_TYPES.ELEMENT_NODE) {
 			return [];
 		}
-		return Array.from(node['attributes']);
+		const attrs = Array.from(node['attributes']) as Attr[];
+		if (bucket === null) {
+			return attrs;
+		}
+		return attrs.filter((attr) => getBucketsForNode(attr).includes(bucket));
 	}
 	public ['getAttribute'](node: Node, attributeName: string): string {
 		if (node.nodeType !== NODE_TYPES.ELEMENT_NODE) {
@@ -15,28 +20,75 @@ export default class ExternalDomFacade implements IDomFacade {
 		}
 		return node['getAttribute'](attributeName);
 	}
-	public ['getChildNodes'](node: Node): Node[] {
-		return Array.from(node['childNodes']);
+	public ['getChildNodes'](node: Node, bucket: string | null = null): Node[] {
+		const childNodes = Array.from(node['childNodes'] as Node[]);
+
+		if (bucket === null) {
+			return childNodes;
+		}
+
+		return childNodes.filter((child) => getBucketsForNode(child).includes(bucket));
 	}
 	public ['getData'](node: Attr | CharacterData): string {
 		return node['nodeType'] === NODE_TYPES.ATTRIBUTE_NODE ? node['value'] : node['data'];
 	}
-	public ['getFirstChild'](node: Node): Node {
-		return node['firstChild'] as Node;
-	}
-	public ['getLastChild'](node: Node): Node {
-		return node['lastChild'] as Node;
-	}
-	public ['getNextSibling'](node: Node): Node {
-		return node['nextSibling'];
-	}
-	public ['getParentNode'](node: Node): Node {
-		if (node['nodeType'] === NODE_TYPES.ATTRIBUTE_NODE) {
-			return node['ownerElement'];
+	public ['getFirstChild'](node: Node, bucket: string | null = null): Node | null {
+		for (let child = node['firstChild'] as Node; child; child = child['nextSibling'] as Node) {
+			if (bucket === null || getBucketsForNode(child).includes(bucket)) {
+				return child;
+			}
 		}
-		return node['parentNode'] as Node;
+
+		return null;
 	}
-	public ['getPreviousSibling'](node: Node): Node {
-		return node['previousSibling'];
+	public ['getLastChild'](node: Node, bucket: string | null = null): Node | null {
+		for (
+			let child = node['lastChild'] as Node;
+			child;
+			child = child['previousSibling'] as Node
+		) {
+			if (bucket === null || getBucketsForNode(child).includes(bucket)) {
+				return child;
+			}
+		}
+
+		return null;
+	}
+	public ['getNextSibling'](node: Node, bucket: string | null = null): Node | null {
+		for (
+			let sibling = node['nextSibling'] as Node;
+			sibling;
+			sibling = sibling['nextSibling'] as Node
+		) {
+			if (bucket === null || getBucketsForNode(sibling).includes(bucket)) {
+				return sibling;
+			}
+		}
+
+		return null;
+	}
+	public ['getParentNode'](node: Node, bucket: string | null = null): Node {
+		const parentNode =
+			node['nodeType'] === NODE_TYPES.ATTRIBUTE_NODE
+				? node['ownerElement']
+				: (node['parentNode'] as Node);
+
+		if (bucket === null || getBucketsForNode(parentNode).includes(bucket)) {
+			return parentNode;
+		}
+		return null;
+	}
+	public ['getPreviousSibling'](node: Node, bucket: string | null = null): Node | null {
+		for (
+			let sibling = node['previousSibling'] as Node;
+			sibling;
+			sibling = sibling['previousSibling'] as Node
+		) {
+			if (bucket === null || getBucketsForNode(sibling).includes(bucket)) {
+				return sibling;
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/expressions/axes/AncestorAxis.ts
+++ b/src/expressions/axes/AncestorAxis.ts
@@ -54,15 +54,23 @@ class AncestorAxis extends Expression {
 		const domFacade = executionParameters.domFacade;
 
 		const contextPointer = contextItem.value;
+		// Similar to the optimization for the Descendant axis, we know that only elements and
+		// document nodes can contain other elements. Therefore, if we are looking for a specific
+		// ancestor element, we only need to visit element ancestors. Because of this, we can pass
+		// the 'type-1' bucket for each parent in that case.
 		const ancestorExpressionBucket = this._ancestorExpression.getBucket();
+		const onlyElementAncestors =
+			ancestorExpressionBucket &&
+			(ancestorExpressionBucket.startsWith('name-') || ancestorExpressionBucket === 'type-1');
+		const ancestorAxisBucket = onlyElementAncestors ? 'type-1' : null;
 		return sequenceFactory
 			.create(
 				generateAncestors(
 					domFacade,
 					this._isInclusive
 						? contextPointer
-						: domFacade.getParentNodePointer(contextPointer, ancestorExpressionBucket),
-					ancestorExpressionBucket
+						: domFacade.getParentNodePointer(contextPointer, ancestorAxisBucket),
+					ancestorAxisBucket
 				)
 			)
 			.filter((item) => {

--- a/test/specs/parsing/axes/AncestorAxis.tests.ts
+++ b/test/specs/parsing/axes/AncestorAxis.tests.ts
@@ -47,7 +47,7 @@ describe('ancestor', () => {
 		jsonMlMapper.parse(['parentElement', ['childElement']], documentNode);
 
 		const childNode = documentNode.firstChild.firstChild;
-		const expectedBucket = getBucketForSelector('self::parentElement');
+		const expectedBucket = getBucketForSelector('self::element()');
 
 		const testDomFacade: IDomFacade = {
 			getParentNode: (node: slimdom.Node, bucket: string | null) => {
@@ -57,6 +57,17 @@ describe('ancestor', () => {
 		} as any;
 
 		evaluateXPathToNodes('ancestor::parentElement', childNode, testDomFacade);
+	});
+
+	it('can move up more than a single step', () => {
+		jsonMlMapper.parse(
+			['works', ['employee'], ['employee', ['overtime', ['day'], ['day']]]],
+			documentNode
+		);
+		chai.assert.deepEqual(
+			evaluateXPathToNodes('/works/employee/overtime/day/ancestor::employee', documentNode),
+			[documentNode.documentElement.lastChild]
+		);
 	});
 });
 
@@ -100,6 +111,20 @@ describe('ancestor-or-self', () => {
 		chai.assert.deepEqual(
 			evaluateXPathToNodes('//someElement/ancestor::*[last()]', documentNode),
 			[documentNode.documentElement]
+		);
+	});
+
+	it('can move up more than a single step', () => {
+		jsonMlMapper.parse(
+			['works', ['employee'], ['employee', ['overtime', ['day'], ['day']]]],
+			documentNode
+		);
+		chai.assert.deepEqual(
+			evaluateXPathToNodes(
+				'/works/employee/overtime/day/ancestor-or-self::employee',
+				documentNode
+			),
+			[documentNode.documentElement.lastChild]
 		);
 	});
 });

--- a/test/specs/parsing/axes/AncestorAxis.tests.ts
+++ b/test/specs/parsing/axes/AncestorAxis.tests.ts
@@ -46,9 +46,7 @@ describe('ancestor', () => {
 	it('passes buckets for ancestor', () => {
 		jsonMlMapper.parse(['parentElement', ['childElement']], documentNode);
 
-		const childNode = documentNode.firstChild.firstChild;
-		const expectedBucket = getBucketForSelector('self::element()');
-
+		let expectedBucket = getBucketForSelector('self::element()');
 		const testDomFacade: IDomFacade = {
 			getParentNode: (node: slimdom.Node, bucket: string | null) => {
 				chai.assert.equal(bucket, expectedBucket);
@@ -56,7 +54,11 @@ describe('ancestor', () => {
 			},
 		} as any;
 
+		const childNode = documentNode.firstChild.firstChild;
 		evaluateXPathToNodes('ancestor::parentElement', childNode, testDomFacade);
+
+		expectedBucket = null;
+		evaluateXPathToNodes('ancestor::*', childNode, testDomFacade);
 	});
 
 	it('can move up more than a single step', () => {
@@ -116,7 +118,7 @@ describe('ancestor-or-self', () => {
 
 	it('can move up more than a single step', () => {
 		jsonMlMapper.parse(
-			['works', ['employee'], ['employee', ['overtime', ['day'], ['day']]]],
+			['works', ['employee'], ['employee', ['overtime', ['day', 'text'], ['day']]]],
 			documentNode
 		);
 		chai.assert.deepEqual(
@@ -125,6 +127,20 @@ describe('ancestor-or-self', () => {
 				documentNode
 			),
 			[documentNode.documentElement.lastChild]
+		);
+		chai.assert.deepEqual(
+			evaluateXPathToNodes(
+				'/works/employee/overtime/day/text()/ancestor-or-self::text()',
+				documentNode
+			),
+			[documentNode.documentElement.lastChild.firstChild.firstChild.firstChild]
+		);
+		chai.assert.deepEqual(
+			evaluateXPathToNodes(
+				'/works/employee/overtime/day/ancestor-or-self::document-node()',
+				documentNode
+			),
+			[documentNode]
 		);
 	});
 });

--- a/test/specs/parsing/axes/DescendantAxis.tests.ts
+++ b/test/specs/parsing/axes/DescendantAxis.tests.ts
@@ -21,7 +21,7 @@ describe('descendant', () => {
 	it('passes buckets for descendant', () => {
 		jsonMlMapper.parse(['parentElement', ['childElement']], documentNode);
 
-		const expectedBucket = null;
+		const expectedBucket = 'type-1';
 
 		const testDomFacade: IDomFacade = {
 			getFirstChild: (node: slimdom.Node, bucket: string | null) => {

--- a/test/specs/parsing/axes/FollowingAxis.tests.ts
+++ b/test/specs/parsing/axes/FollowingAxis.tests.ts
@@ -111,19 +111,19 @@ return map{
 		);
 
 		const firstChildNode = documentNode.firstChild.firstChild;
-		const expectedBucket = getBucketForSelector('self::secondChildElement');
+		const expectedBucket = getBucketForSelector('self::element()');
 
 		const testDomFacade: IDomFacade = {
 			getFirstChild: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, expectedBucket);
 				return node.firstChild;
 			},
 			getNextSibling: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, expectedBucket);
 				return node.nextSibling;
 			},
 			getParentNode: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, null);
 				return node.parentNode;
 			},
 		} as any;

--- a/test/specs/parsing/axes/PrecedingAxis.tests.ts
+++ b/test/specs/parsing/axes/PrecedingAxis.tests.ts
@@ -135,23 +135,23 @@ return map{
 		);
 
 		const secondChildNode = documentNode.firstChild.lastChild;
-		const expectedBucket = getBucketForSelector('self::firstChildElement');
+		const expectedBucket = getBucketForSelector('self::element()');
 
 		const testDomFacade: IDomFacade = {
 			getChildNodes: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, expectedBucket);
 				return node.childNodes;
 			},
 			getLastChild: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, expectedBucket);
 				return node.lastChild;
 			},
 			getParentNode: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, null);
 				return node.parentNode;
 			},
 			getPreviousSibling: (node: slimdom.Node, bucket: string | null) => {
-				chai.assert.equal(expectedBucket, bucket);
+				chai.assert.equal(bucket, expectedBucket);
 				return node.previousSibling;
 			},
 		} as any;


### PR DESCRIPTION
When we do a `descendant::ele`, we are never interested in anything but Elements. Therefore, we can
pass this bucket. This can then be used to minimize the kinds of mutations that will invalidate the
whole expressions: adding textnodes for example will no longer invalidate the query.