### PR TITLE
Set a new default function namespace with the Javascript API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
   * `logger` `<Object>` Object with functions used to override the standard logger.
     * `trace: <function(string):void>` The logger for the `trace()` function. The argument is the
       string of the original message.
+  * `defaultFunctionNamespaceURI` `<string>` To modify or change the default function namespaceURI. Defaults to `http://www.w3.org/2005/xpath-functions`. Defining the default function namespaceURI in the xpath expression overwrites this option.
 
 ### Example
 
@@ -85,8 +86,10 @@ const {
 	evaluateXPath,
 	evaluateXPathToBoolean,
 	evaluateXPathToString,
-	evaluateXPathToFirstNode
+	evaluateXPathToFirstNode,
+    evaluateXPathToNumber,
 } = require('fontoxpath');
+
 const documentNode = new DOMParser().parseFromString('<xml/>', 'text/xml');
 
 console.log(evaluateXPathToBoolean('/xml => exists()', documentNode));
@@ -98,6 +101,10 @@ console.log(evaluateXPathToString('$foo', null, null, {'foo': 'bar'}));
 // We pass the documentNode so the default INodesFactory can be used.
 console.log(evaluateXPathToFirstNode('<foo>bar</foo>', documentNode, null, null, {language: evaluateXPath.XQUERY_3_1_LANGUAGE}).outerHTML);
 // Outputs: "<foo>bar</foo>"
+
+// We pass the Math namespaceURI for the pi() function to be used
+console.log(evaluateXPathToNumber('pi()', documentNode, undefined, {}, { language: evaluateXPath.XQUERY_3_1_LANGUAGE, defaultFunctionNamespaceURI: 'http://www.w3.org/2005/xpath-functions/math'}));
+// Outputs: Math.PI (3.14...)
 ```
 
 ### Debugging

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const {
 	evaluateXPathToBoolean,
 	evaluateXPathToString,
 	evaluateXPathToFirstNode,
-    evaluateXPathToNumber,
+        evaluateXPathToNumber,
 } = require('fontoxpath');
 
 const documentNode = new DOMParser().parseFromString('<xml/>', 'text/xml');

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const {
 	evaluateXPathToBoolean,
 	evaluateXPathToString,
 	evaluateXPathToFirstNode,
-        evaluateXPathToNumber,
+	evaluateXPathToNumber,
 } = require('fontoxpath');
 
 const documentNode = new DOMParser().parseFromString('<xml/>', 'text/xml');

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -23,6 +23,7 @@ export type Logger = {
 export type Options = {
 	currentContext?: any;
 	debug?: boolean;
+	defaultFunctionNamespaceURI?: string;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
 	language?: Language;

--- a/src/evaluationUtils/buildContext.ts
+++ b/src/evaluationUtils/buildContext.ts
@@ -17,6 +17,7 @@ import INodesFactory from '../nodesFactory/INodesFactory';
 import wrapExternalNodesFactory from '../nodesFactory/wrapExternalNodesFactory';
 import staticallyCompileXPath from '../parsing/staticallyCompileXPath';
 import { Node } from '../types/Types';
+import { FUNCTIONS_NAMESPACE_URI } from '../expressions/staticallyKnownNamespaces';
 
 const generateGlobalVariableBindingName = (variableName: string) => `Q{}${variableName}[0]`;
 
@@ -93,12 +94,17 @@ export default function buildEvaluationContext(
 
 	const namespaceResolver =
 		internalOptions.namespaceResolver || createDefaultNamespaceResolver(contextItem);
+
+	const defaultFunctionNamespaceURI =
+		externalOptions['defaultFunctionNamespaceURI'] || FUNCTIONS_NAMESPACE_URI;
+
 	const expressionAndStaticContext = staticallyCompileXPath(
 		expressionString,
 		compilationOptions,
 		namespaceResolver,
 		variables,
-		moduleImports
+		moduleImports,
+		defaultFunctionNamespaceURI
 	);
 
 	const contextSequence = contextItem

--- a/src/expressions/ExecutionSpecificStaticContext.ts
+++ b/src/expressions/ExecutionSpecificStaticContext.ts
@@ -44,8 +44,14 @@ export default class ExecutionSpecificStaticContext implements IContext {
 	private _variableBindingByName: { [variableName: string]: string };
 	private _variableValueByName: any;
 
-	constructor(namespaceResolver: (prefix: string) => string | null, variableByName: object) {
+	constructor(
+		namespaceResolver: (prefix: string) => string | null,
+		variableByName: object,
+		defaultFunctionNamespaceURI: string
+	) {
 		this._namespaceResolver = namespaceResolver;
+		this.registeredDefaultFunctionNamespace = defaultFunctionNamespaceURI;
+
 		this._variableBindingByName = Object.keys(variableByName).reduce(
 			(bindings, variableName) => {
 				if (variableByName[variableName] === undefined) {

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -9,7 +9,7 @@ import sequenceFactory from '../dataTypes/sequenceFactory';
 import Value from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionSpecificStaticContext from '../ExecutionSpecificStaticContext';
-import { FONTOXPATH_NAMESPACE_URI } from '../staticallyKnownNamespaces';
+import { FONTOXPATH_NAMESPACE_URI, FUNCTIONS_NAMESPACE_URI } from '../staticallyKnownNamespaces';
 import StaticContext from '../StaticContext';
 import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
 import { DONE_TOKEN, IAsyncIterator, IterationHint, notReady, ready } from '../util/iterators';
@@ -51,7 +51,8 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 					Object.keys(variables).reduce((vars, varName) => {
 						vars[varName] = varName;
 						return vars;
-					}, {})
+					}, {}),
+					FUNCTIONS_NAMESPACE_URI
 				);
 				const innerStaticContext = new StaticContext(executionSpecificStaticContext);
 

--- a/src/parsing/compiledExpressionCache.ts
+++ b/src/parsing/compiledExpressionCache.ts
@@ -9,6 +9,7 @@ const halfCompiledExpressionCache: { [s: string]: { [s: string]: Expression } } 
 
 class CacheEntry {
 	public compiledExpression: Expression;
+	public defaultFunctionNamespaceURI: string;
 	public moduleImports: { namespaceURI: string; prefix: string }[];
 	public referredNamespaces: { namespaceURI: string; prefix: string }[];
 	public referredVariables: { name: string }[];
@@ -19,12 +20,14 @@ class CacheEntry {
 		compiledExpression: Expression,
 		moduleImports:
 			| { namespaceURI: any; prefix: string }[]
-			| { namespaceURI: string; prefix: string }[]
+			| { namespaceURI: string; prefix: string }[],
+		defaultFunctionNamespaceURI: string
 	) {
 		this.compiledExpression = compiledExpression;
 		this.moduleImports = moduleImports;
 		this.referredNamespaces = referredNamespaces;
 		this.referredVariables = referredVariables;
+		this.defaultFunctionNamespaceURI = defaultFunctionNamespaceURI;
 	}
 }
 
@@ -79,7 +82,8 @@ export function getStaticCompilationResultFromCache(
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
 	moduleImports: { [x: string]: string },
-	debug: boolean
+	debug: boolean,
+	defaultFunctionNamespaceURI: string
 ) {
 	const cachesForExpression = compiledExpressionCache[selectorString];
 
@@ -114,6 +118,7 @@ export function getStaticCompilationResultFromCache(
 
 	const cacheWithCorrectContext = cachesForLanguage.find(
 		(cache) =>
+			cache.defaultFunctionNamespaceURI === defaultFunctionNamespaceURI &&
 			cache.referredNamespaces.every(
 				(nsRef) => namespaceResolver(nsRef.prefix) === nsRef.namespaceURI
 			) &&
@@ -164,7 +169,8 @@ export function storeStaticCompilationResultInCache(
 	executionStaticContext: ExecutionSpecificStaticContext,
 	moduleImports: { [x: string]: any },
 	compiledExpression: Expression,
-	debug: boolean
+	debug: boolean,
+	defaultFunctionNamespaceURI: string
 ) {
 	removeHalfCompiledExpression(selectorString, language, debug, compiledExpression);
 
@@ -187,7 +193,8 @@ export function storeStaticCompilationResultInCache(
 			Object.keys(moduleImports).map((moduleImportPrefix) => ({
 				namespaceURI: moduleImports[moduleImportPrefix],
 				prefix: moduleImportPrefix,
-			}))
+			})),
+			defaultFunctionNamespaceURI
 		)
 	);
 }

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -24,7 +24,8 @@ export default function staticallyCompileXPath(
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
-	moduleImports: { [namespaceURI: string]: string }
+	moduleImports: { [namespaceURI: string]: string },
+	defaultFunctionNamespaceURI: string
 ): { expression: Expression; staticContext: StaticContext } {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 
@@ -36,12 +37,14 @@ export default function staticallyCompileXPath(
 				namespaceResolver,
 				variables,
 				moduleImports,
-				compilationOptions.debug
+				compilationOptions.debug,
+				defaultFunctionNamespaceURI
 		  );
 
 	const executionSpecificStaticContext = new ExecutionSpecificStaticContext(
 		namespaceResolver,
-		variables
+		variables,
+		defaultFunctionNamespaceURI
 	);
 	const rootStaticContext = new StaticContext(executionSpecificStaticContext);
 
@@ -91,7 +94,8 @@ export default function staticallyCompileXPath(
 				executionSpecificStaticContext,
 				moduleImports,
 				expression,
-				compilationOptions.debug
+				compilationOptions.debug,
+				defaultFunctionNamespaceURI
 			);
 		}
 	}

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -5,6 +5,7 @@ import astHelper from './parsing/astHelper';
 import { loadModuleFile } from './parsing/globalModuleCache';
 import parseExpression from './parsing/parseExpression';
 import processProlog, { FunctionDeclaration } from './parsing/processProlog';
+import { FUNCTIONS_NAMESPACE_URI } from './expressions/staticallyKnownNamespaces';
 
 /**
  * Register an XQuery module
@@ -33,7 +34,7 @@ export default function registerXQueryModule(
 	const moduleTargetPrefix = astHelper.getTextContent(prefixNode);
 
 	const staticContext = new StaticContext(
-		new ExecutionSpecificStaticContext(() => null, Object.create(null))
+		new ExecutionSpecificStaticContext(() => null, Object.create(null), FUNCTIONS_NAMESPACE_URI)
 	);
 
 	staticContext.registerNamespace(moduleTargetPrefix, moduleTargetNamespaceURI);

--- a/test/specs/parsing/xquery/DefaultFunctionNamespace.tests.ts
+++ b/test/specs/parsing/xquery/DefaultFunctionNamespace.tests.ts
@@ -87,3 +87,68 @@ describe('DefaultFunctionDeclaration', () => {
 		);
 	});
 });
+
+describe('Using Javascript API to set a new default function namespace', () => {
+	it('Set a new default function namespace via options', () => {
+		chai.assert.equal(
+			evaluateXPathToNumber(
+				'pi()',
+				documentNode,
+				undefined,
+				{},
+				{
+					language: evaluateXPath.XQUERY_3_1_LANGUAGE,
+					defaultFunctionNamespaceURI: 'http://www.w3.org/2005/xpath-functions/math',
+				}
+			),
+			Math.PI
+		);
+	});
+
+	it('Checking if the declared default namespace is used instead of the one passed in options', () => {
+		chai.assert.equal(
+			evaluateXPathToNumber(
+				'declare default function namespace "http://www.w3.org/2005/xpath-functions/math"; pi()',
+				documentNode,
+				undefined,
+				{},
+				{
+					language: evaluateXPath.XQUERY_3_1_LANGUAGE,
+					defaultFunctionNamespaceURI: 'testNamespace',
+				}
+			),
+			Math.PI
+		);
+	});
+
+	it('Checking Empty String defaultFunctionNamespaceURI case throws error', () => {
+		chai.assert.throws(
+			() =>
+				evaluateXPathToNumber(
+					'pi()',
+					documentNode,
+					undefined,
+					{},
+					{ language: evaluateXPath.XQUERY_3_1_LANGUAGE, defaultFunctionNamespaceURI: '' }
+				),
+			'XPST0017: Function pi with arity of 0 not registered. Did you mean "Q{http://www.w3.org/2005/xpath-functions/math}pi ()"?'
+		);
+	});
+
+	it('Checking Empty String defaultFunctionNamespaceURI case throws error', () => {
+		chai.assert.throws(
+			() =>
+				evaluateXPathToNumber(
+					'pi()',
+					documentNode,
+					undefined,
+					{},
+					{
+						language: evaluateXPath.XQUERY_3_1_LANGUAGE,
+						defaultFunctionNamespaceURI: null,
+					}
+				),
+			'XPST0017: Function pi with arity of 0 not registered. Did you mean "Q{http://www.w3.org/2005/xpath-functions/math}pi ()"?'
+		);
+	});
+});


### PR DESCRIPTION
Add a way for the Javascript API to set a new default function namespace

Modify the cache to ensure that a new cache entry is created if the default function namespace changes

This fixes issue #256