### PR TITLE
Remove the useless window part to set xspattern

### DIFF
--- a/build.js
+++ b/build.js
@@ -80,11 +80,10 @@ function doTSCCBuild() {
 				assume_function_wrapper: true,
 				compilation_level: 'ADVANCED',
 				output_wrapper: `function (xspattern) {
-	const window = {};
-	window.xspattern = xspattern;
-	var VERSION='${require('./package.json').version}';
-	%output%
-	return window;
+const VERSION='${require('./package.json').version}';
+const fontoxpathGlobal = {};
+%output%
+return fontoxpathGlobal;
 }
 `,
 			},

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,34 +99,34 @@ function compareSpecificity(xpathStringA: string, xpathStringB: string): -1 | 0 
 const domFacade = new ExternalDomFacade() as IDomFacade;
 
 // This declaration is needed, as we don't depend anymore on lib.dom.
-declare var window;
+declare var fontoxpathGlobal;
 
 /* istanbul ignore next */
-if (typeof window !== 'undefined') {
-	window['compareSpecificity'] = compareSpecificity;
-	window['domFacade'] = domFacade;
-	window['evaluateXPath'] = evaluateXPath;
-	window['evaluateXPathToArray'] = evaluateXPathToArray;
-	window['evaluateXPathToBoolean'] = evaluateXPathToBoolean;
-	window['evaluateXPathToAsyncIterator'] = evaluateXPathToAsyncIterator;
-	window['evaluateXPathToFirstNode'] = evaluateXPathToFirstNode;
-	window['evaluateXPathToMap'] = evaluateXPathToMap;
-	window['evaluateXPathToNodes'] = evaluateXPathToNodes;
-	window['evaluateXPathToNumber'] = evaluateXPathToNumber;
-	window['evaluateXPathToNumbers'] = evaluateXPathToNumbers;
-	window['evaluateXPathToString'] = evaluateXPathToString;
-	window['evaluateXPathToStrings'] = evaluateXPathToStrings;
-	window['evaluateUpdatingExpression'] = evaluateUpdatingExpression;
-	window['evaluateUpdatingExpressionSync'] = evaluateUpdatingExpressionSync;
-	window['executePendingUpdateList'] = executePendingUpdateList;
-	window['getBucketForSelector'] = getBucketForSelector;
-	window['getBucketsForNode'] = getBucketsForNode;
+if (typeof fontoxpathGlobal !== 'undefined') {
+	fontoxpathGlobal['compareSpecificity'] = compareSpecificity;
+	fontoxpathGlobal['domFacade'] = domFacade;
+	fontoxpathGlobal['evaluateXPath'] = evaluateXPath;
+	fontoxpathGlobal['evaluateXPathToArray'] = evaluateXPathToArray;
+	fontoxpathGlobal['evaluateXPathToBoolean'] = evaluateXPathToBoolean;
+	fontoxpathGlobal['evaluateXPathToAsyncIterator'] = evaluateXPathToAsyncIterator;
+	fontoxpathGlobal['evaluateXPathToFirstNode'] = evaluateXPathToFirstNode;
+	fontoxpathGlobal['evaluateXPathToMap'] = evaluateXPathToMap;
+	fontoxpathGlobal['evaluateXPathToNodes'] = evaluateXPathToNodes;
+	fontoxpathGlobal['evaluateXPathToNumber'] = evaluateXPathToNumber;
+	fontoxpathGlobal['evaluateXPathToNumbers'] = evaluateXPathToNumbers;
+	fontoxpathGlobal['evaluateXPathToString'] = evaluateXPathToString;
+	fontoxpathGlobal['evaluateXPathToStrings'] = evaluateXPathToStrings;
+	fontoxpathGlobal['evaluateUpdatingExpression'] = evaluateUpdatingExpression;
+	fontoxpathGlobal['evaluateUpdatingExpressionSync'] = evaluateUpdatingExpressionSync;
+	fontoxpathGlobal['executePendingUpdateList'] = executePendingUpdateList;
+	fontoxpathGlobal['getBucketForSelector'] = getBucketForSelector;
+	fontoxpathGlobal['getBucketsForNode'] = getBucketsForNode;
 	/** @suppress {deprecated} */
 	// @ts-ignore We still need to expose this deprecated API
-	window['precompileXPath'] = precompileXPath;
-	window['registerXQueryModule'] = registerXQueryModule;
-	window['registerCustomXPathFunction'] = registerCustomXPathFunction;
-	window['parseScript'] = parseScript;
+	fontoxpathGlobal['precompileXPath'] = precompileXPath;
+	fontoxpathGlobal['registerXQueryModule'] = registerXQueryModule;
+	fontoxpathGlobal['registerCustomXPathFunction'] = registerCustomXPathFunction;
+	fontoxpathGlobal['parseScript'] = parseScript;
 }
 
 export {


### PR DESCRIPTION
It causes issues later on where we cannot find polyfils for Promise or something similar.

Fingers crossed the CI likes it too, because some project I am including fontoxpath in likes it!