### PR TITLE
Fix ESM build

### DIFF
--- a/build.js
+++ b/build.js
@@ -78,6 +78,7 @@ function doTSCCBuild() {
 			prefix: './',
 			compilerFlags: {
 				assume_function_wrapper: true,
+				language_out: 'ECMASCRIPT_NEXT',
 				compilation_level: 'ADVANCED',
 				output_wrapper: `function (xspattern) {
 const VERSION='${require('./package.json').version}';

--- a/build.js
+++ b/build.js
@@ -78,7 +78,6 @@ function doTSCCBuild() {
 			prefix: './',
 			compilerFlags: {
 				assume_function_wrapper: true,
-				language_out: 'ECMASCRIPT_NEXT',
 				compilation_level: 'ADVANCED',
 				output_wrapper: `function (xspattern) {
 const VERSION='${require('./package.json').version}';
@@ -111,7 +110,8 @@ function doModuleBuild() {
 
 	const fontoxpathFunction = fs.readFileSync('./dist/fontoxpath-raw.js', 'utf8');
 	const fullModule = `import * as xspattern from 'xspattern';
-const fontoxpath = (${fontoxpathFunction})(xspattern);
+const fontoxpath = (${fontoxpathFunction})
+	.call(typeof window === 'undefined' ? undefined : window, xspattern);
 ${exports.join('\n')};
 export default fontoxpath;
 `;


### PR DESCRIPTION
Previously, the ESM build could throw errors like 'cannot read Promise of undefined' because the polyfills assume the `this` property of a function to be equal to `window`.

These changes make the ESM build work as expected when you 'just load it' without any build tools mangling things.