### PR TITLE
Dev 8442

### DIFF
--- a/test/specs/parsing/registerCustomXPathFunction.tests.ts
+++ b/test/specs/parsing/registerCustomXPathFunction.tests.ts
@@ -269,6 +269,19 @@ describe('registerCustomXPathFunction', () => {
 		);
 	});
 
+	it('disallows registering in the default namespace', () => {
+		chai.assert.throws(
+			() =>
+				registerCustomXPathFunction(
+					'custom-function-in-no-ns',
+					[],
+					'xs:boolean',
+					() => true
+				),
+			'Do not register custom functions in the default function namespace'
+		);
+	});
+
 	it('disallows attributes as parameters', () => {
 		chai.assert.throws(
 			() =>


### PR DESCRIPTION
We now include the JS call stack for custom xpath functions. The approach we took also prevents a JS callstack when the error is raised by a XPath expression. (see last unit test which exectues `$map("key")` ).

The story on JIRA contains an example of how this error is displayed in Fonto Editor.