### PR TITLE
Inline xpath parser

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,9 +23,11 @@ function doPegJsBuild() {
 				exportVar: 'xPathParser',
 			})
 			 )
-	// Note the ts-nocheck, the output of pegJs is not valid TypeScript. The tslint-disable disables linter errors.
+	// Note the ts-nocheck, the output of pegJs is not valid TypeScript. The tslint-disable disables
+	// linter errors. Also, don't measure code coverage on this file. It is generated.
 		.then((parserString) => `// @ts-nocheck
 /* tslint:disable */
+// @coverage(false)
 
 // HACK: PegJS uses a single object with keys that are later indexed using strings,
 //  this is incompatible with the closure compiler.

--- a/build.js
+++ b/build.js
@@ -87,7 +87,7 @@ function doTSCCBuild() {
 			},
 			prefix: './',
 			compilerFlags: {
-				debug: true,
+				debug: false,
 				assume_function_wrapper: true,
 				compilation_level: 'ADVANCED',
 				output_wrapper: `function (xspattern) {

--- a/build.js
+++ b/build.js
@@ -27,7 +27,7 @@ function doPegJsBuild() {
 	// linter errors. Also, don't measure code coverage on this file. It is generated.
 		.then((parserString) => `// @ts-nocheck
 /* tslint:disable */
-// @coverage(false)
+/* istanbul ignore file */
 
 // HACK: PegJS uses a single object with keys that are later indexed using strings,
 //  this is incompatible with the closure compiler.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,8 +49,7 @@
 				"tslint": "^6.1.3",
 				"tslint-config-prettier": "^1.18.0",
 				"ttypescript": "^1.5.12",
-				"typescript": "^3.8.3",
-				"uglify-js": "^3.8.0"
+				"typescript": "^3.8.3"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -7822,22 +7821,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/uglify-js": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-			"integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-			"dev": true,
-			"dependencies": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
-			},
-			"bin": {
-				"uglifyjs": "bin/uglifyjs"
-			},
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
 		"node_modules/unc-path-regex": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
@@ -14968,16 +14951,6 @@
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
 			"integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==",
 			"dev": true
-		},
-		"uglify-js": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-			"integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
-			"dev": true,
-			"requires": {
-				"commander": "~2.20.3",
-				"source-map": "~0.6.1"
-			}
 		},
 		"unc-path-regex": {
 			"version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -99,8 +99,7 @@
 		"tslint": "^6.1.3",
 		"tslint-config-prettier": "^1.18.0",
 		"ttypescript": "^1.5.12",
-		"typescript": "^3.8.3",
-		"uglify-js": "^3.8.0"
+		"typescript": "^3.8.3"
 	},
 	"dependencies": {
 		"xspattern": "^2.0.0"

--- a/src/evaluationUtils/PositionedError.ts
+++ b/src/evaluationUtils/PositionedError.ts
@@ -5,16 +5,16 @@ export class PositionedError extends Error {
 
 	constructor(message: string, position: SourceRange) {
 		super(message);
-		this['position'] = {
-			['end']: {
-				['column']: position.end.column,
-				['line']: position.end.line,
-				['offset']: position.end.offset,
+		this.position = {
+			end: {
+				column: position.end.column,
+				line: position.end.line,
+				offset: position.end.offset,
 			},
-			['start']: {
-				['column']: position.start.column,
-				['line']: position.start.line,
-				['offset']: position.start.offset,
+			start: {
+				column: position.start.column,
+				line: position.start.line,
+				offset: position.start.offset,
 			},
 		};
 	}

--- a/src/expressions/debug/StackTraceEntry.ts
+++ b/src/expressions/debug/StackTraceEntry.ts
@@ -23,7 +23,7 @@ export class StackTraceEntry {
 
 	public makeStackTrace(): string[] {
 		let innerStackTrace: string[];
-		if ('position' in this.innerTrace) {
+		if (this.innerTrace instanceof PositionedError) {
 			// We are dealing with a nested positioned error
 			innerStackTrace = ['Inner error:', this.innerTrace.message];
 		} else if (this.innerTrace instanceof Error) {

--- a/src/expressions/debug/StackTraceGenerator.ts
+++ b/src/expressions/debug/StackTraceGenerator.ts
@@ -24,14 +24,14 @@ export default class StackTraceGenerator extends PossiblyUpdatingExpression {
 
 		this._location = {
 			end: {
-				column: location['end']['column'],
-				line: location['end']['line'],
-				offset: location['end']['offset'],
+				column: location.end.column,
+				line: location.end.line,
+				offset: location.end.offset,
 			},
 			start: {
-				column: location['start']['column'],
-				line: location['start']['line'],
-				offset: location['start']['offset'],
+				column: location.start.column,
+				line: location.start.line,
+				offset: location.start.offset,
 			},
 		};
 	}

--- a/src/expressions/functions/builtInFunctions_sequences.ts
+++ b/src/expressions/functions/builtInFunctions_sequences.ts
@@ -474,7 +474,7 @@ const fnExactlyOne: FunctionDefinitionType = (
 ) => {
 	if (!arg.isSingleton()) {
 		throw new Error(
-			'FORG0005: The argument passed to fn:exactly-one is empty or contained more then one item.'
+			'FORG0005: The argument passed to fn:exactly-one is empty or contained more than one item.'
 		);
 	}
 	return arg;

--- a/src/parsing/parseExpression.ts
+++ b/src/parsing/parseExpression.ts
@@ -30,8 +30,8 @@ export default function parseExpression(
 			ast = cached;
 		} else {
 			ast = parse(xPathString, {
-				['xquery']: !!compilationOptions.allowXQuery,
-				['outputDebugInfo']: !!compilationOptions.debug,
+				xquery: !!compilationOptions.allowXQuery,
+				outputDebugInfo: !!compilationOptions.debug,
 			});
 			if (!compilationOptions.debug) {
 				storeParseResultInCache(xPathString, language, ast);
@@ -42,9 +42,9 @@ export default function parseExpression(
 		if (error instanceof SyntaxError) {
 			throw new Error(
 				`XPST0003: Unable to parse: "${xPathString}".\n${error.message}\n${
-					xPathString.slice(0, error['location']['start']['offset']) +
+					xPathString.slice(0, error.location.start.offset) +
 					'[Error is around here]' +
-					xPathString.slice(error['location']['start']['offset'])
+					xPathString.slice(error.location.start.offset)
 				}`
 			);
 		}

--- a/src/parsing/xPathParser.ts
+++ b/src/parsing/xPathParser.ts
@@ -3,13 +3,12 @@ import xPathParserRaw from './xPathParser_raw';
 
 const xpathModule: any = {};
 
-// tslint:disable-next-line:function-constructor
-new Function(xPathParserRaw()).call(xpathModule);
+xPathParserRaw(xpathModule);
 
-const xpathParserModule = xpathModule['xPathParser'];
-export const parse = xpathParserModule['parse'] as (
+const xpathParserModule = xpathModule.xPathParser;
+export const parse = xpathParserModule.parse as (
 	source: string,
 	params: { outputDebugInfo: boolean; xquery: boolean }
 ) => IAST;
-// tslint:disable-next-line:variable-name
-export const SyntaxError = xpathParserModule['SyntaxError'];
+
+export const SyntaxError = xpathParserModule.SyntaxError;

--- a/src/parsing/xpath.pegjs
+++ b/src/parsing/xpath.pegjs
@@ -1338,7 +1338,7 @@ ParenthesizedItemType = "(" _ type:ItemType _ ")" {return ["parenthesizedItemTyp
 URILiteral = StringLiteral
 
 // 218
-EQName = uri:URIQualifiedName {return [{prefix: null, URI: uri[0]}, uri[1]]}
+EQName = uri:URIQualifiedName {return [{['prefix']: null, ['URI']: uri[0]}, uri[1]]}
  / QName
 
 // 219
@@ -1481,7 +1481,7 @@ WhitespaceCharacter
  / Comment // Note: comments can occur anywhere where whitespace is allowed: https://www.w3.org/TR/xpath-3/#DefaultWhitespaceHandling
 
 // XML Types
-PrefixedName = prefix:XMLPrefix ":" local:LocalPart {return [{prefix: prefix}, local]}
+PrefixedName = prefix:XMLPrefix ":" local:LocalPart {return [{['prefix']: prefix}, local]}
 
 UnprefixedName = local:LocalPart {return [local]}
 

--- a/test/specs/parsing/debug/stackTrace.tests.ts
+++ b/test/specs/parsing/debug/stackTrace.tests.ts
@@ -232,29 +232,6 @@ Error: XPST0008, The variable map is not in scope.
 		);
 	});
 
-	it('contains the correct location of the error in the code', () => {
-		const errorLine = '$map("key")';
-		const position = {
-			end: {
-				column: 12,
-				line: 7,
-				offset: 41,
-			},
-			start: {
-				column: 1,
-				line: 7,
-				offset: 30,
-			},
-		};
-		try {
-			const lines = Array(10).fill('(::)');
-			lines[6] = errorLine;
-			evaluateXPath(lines.join('\n'), null, null, null, null, { debug: true });
-		} catch (error) {
-			chai.assert.deepEqual(error.position, position);
-		}
-	});
-
 	it('shows the JS stack trace for error in a custom xpath function', () => {
 		try {
 			evaluateXPath('Q{test}boom-abc()', null, null, null, null, { debug: true });


### PR DESCRIPTION
Refactor the build of the XPath parser to no longer need UglifyJS and the `new Function()` trick to include the parser.

This also removes a few of those Closure tricks to prevent renaming of fields: those are the changes of `x["something"]` to `x.something`