### PR TITLE
Add support for js-codegen in fuzzer

### DIFF
--- a/fuzzers/corpus_based_fuzzer.ts
+++ b/fuzzers/corpus_based_fuzzer.ts
@@ -1,5 +1,11 @@
 import { FuzzCase, IFuzzer } from 'fuzzer';
-import { mutateCharactersInPlace, mutateString, rand, randomLanguage } from 'mutators';
+import {
+	mutateCharactersInPlace,
+	mutateString,
+	rand,
+	randomBackend,
+	randomLanguage,
+} from 'mutators';
 import { sync } from 'slimdom-sax-parser';
 
 /**
@@ -58,6 +64,8 @@ export default class CorpusBasedFuzzer implements IFuzzer {
 		// Select a random language
 		const language = randomLanguage();
 
-		return new FuzzCase(expression, language, this.documentNode);
+		const backend = randomBackend();
+
+		return new FuzzCase(expression, language, backend, this.documentNode);
 	}
 }

--- a/fuzzers/engine.ts
+++ b/fuzzers/engine.ts
@@ -67,7 +67,7 @@ export default class Engine<TFuzzer extends IFuzzer> {
 
 						// Print the error
 						process.stdout.write(
-							`\n\n!!! \x1b[31mCrash found\x1b[0m !!!\nSelector: ${msg.selector}\nLanguage: ${msg.language}\n${msg.stack}\n\n`
+							`\n\n!!! \x1b[31mCrash found\x1b[0m !!!\nSelector: ${msg.selector}\nLanguage: ${msg.language}\nBackend: ${msg.backend}\n${msg.stack}\n\n`
 						);
 						break;
 					}
@@ -147,6 +147,7 @@ export default class Engine<TFuzzer extends IFuzzer> {
 					type: WorkerMessageTypes.Crash,
 					selector: fuzzCase.selector,
 					language: fuzzCase.language,
+					backend: fuzzCase.backend,
 					stack: error.stack,
 					tid
 				});

--- a/fuzzers/fuzzer.ts
+++ b/fuzzers/fuzzer.ts
@@ -1,6 +1,6 @@
 import {
-	evaluateXPath,
 	compileXPathToJavaScript,
+	evaluateXPath,
 	executeJavaScriptCompiledXPath,
 } from 'fontoxpath';
 

--- a/fuzzers/fuzzer.ts
+++ b/fuzzers/fuzzer.ts
@@ -19,10 +19,10 @@ export interface IFuzzer {
  * A single executable fuzz case.
  */
 export class FuzzCase {
+	backend: Backend;
 	contextItem?: any | null;
 	language: string;
 	selector: string;
-	backend: Backend;
 
 	constructor(selector: string, language: string, backend: Backend, contextItem?: any | null) {
 		this.selector = selector;

--- a/fuzzers/fuzzer.ts
+++ b/fuzzers/fuzzer.ts
@@ -4,7 +4,7 @@ import {
 	executeJavaScriptCompiledXPath,
 } from 'fontoxpath';
 
-import { Backend } from 'mutators';
+import { BACKEND } from 'mutators';
 
 /**
  * Interface for fuzzer which are run by the {@link Engine}.
@@ -19,12 +19,12 @@ export interface IFuzzer {
  * A single executable fuzz case.
  */
 export class FuzzCase {
-	backend: Backend;
+	backend: BACKEND;
 	contextItem?: any | null;
 	language: string;
 	selector: string;
 
-	constructor(selector: string, language: string, backend: Backend, contextItem?: any | null) {
+	constructor(selector: string, language: string, backend: BACKEND, contextItem?: any | null) {
 		this.selector = selector;
 		this.language = language;
 		this.backend = backend;
@@ -38,9 +38,9 @@ export class FuzzCase {
 		};
 
 		// Execute the expression using the given backend.
-		if (this.backend === 'expression') {
+		if (this.backend === BACKEND.EXPRESSION) {
 			evaluateXPath(this.selector, this.contextItem, null, null, null, options);
-		} else if (this.backend === 'js-codegen') {
+		} else if (this.backend === BACKEND.JS_CODEGEN) {
 			const compiledXPathResult = compileXPathToJavaScript(
 				this.selector,
 				evaluateXPath.BOOLEAN_TYPE,

--- a/fuzzers/mutators.ts
+++ b/fuzzers/mutators.ts
@@ -29,21 +29,23 @@ export function randomLanguage(): string {
 	}
 }
 
-// We use string values because they can be printed when reporting errors.
-export type Backend = 'expression' | 'js-codegen';
+export enum BACKEND {
+	EXPRESSION = 'expression',
+	JS_CODEGEN = 'js-codegen',
+}
 
 /**
  * Pick a random backend.
  *
  * @returns The randomly selected backend.
  */
-export function randomBackend(): Backend {
+export function randomBackend(): BACKEND {
 	const index = rand(2);
 	switch (index) {
 		case 0:
-			return 'expression';
+			return BACKEND.EXPRESSION;
 		case 1:
-			return 'js-codegen';
+			return BACKEND.JS_CODEGEN;
 		default:
 			throw new Error('Out of bounds');
 	}

--- a/fuzzers/mutators.ts
+++ b/fuzzers/mutators.ts
@@ -29,6 +29,26 @@ export function randomLanguage(): string {
 	}
 }
 
+// We use string values because they can be printed when reporting errors.
+export type Backend = 'expression' | 'js-codegen';
+
+/**
+ * Pick a random backend.
+ *
+ * @returns The randomly selected backend.
+ */
+export function randomBackend(): Backend {
+	const index = rand(2);
+	switch (index) {
+		case 0:
+			return 'expression';
+		case 1:
+			return 'js-codegen';
+		default:
+			throw new Error('Out of bounds');
+	}
+}
+
 const STRING_POOL =
 	'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-[]{}()<>,./?:;"\'|\\!@#$%^&*+=';
 function randomString(len: number): string {


### PR DESCRIPTION
Integrate js-codegen in fuzzer. A similar approach to choosing a language for a `FuzzCase` is chosen, but instead of a language, a backend is randomly picked.