### PR TITLE
[minor] Add a new ResultType.ALL_RESULTS that does no magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
     be used for querying the DOM. Defaults to an implementation which uses properties and methods on
     the `contextNode` as described in the [DOM spec](https://dom.spec.whatwg.org/).
 -   `variables` `<Object>` The properties of `variables` are available variables within the
-    `xpathExpression`. Defaults to an empty `Object`. Can only be used to set variables in the global namespace.
+    `xpathExpression`. Defaults to an empty `Object`. Can only be used to set variables in the
+    global namespace.
 -   `returnType` `<number>` Determines the type of the result. Defaults to
     `evaluateXPath.ANY_TYPE`. Possible values:
-    -   `evaluateXPath.ANY_TYPE` Returns the result of the query, can be anything depending on the
-        query. Note that the return type is determined dynamically, not statically: XPaths returning
-        empty sequences will return empty arrays and not null, like one might expect.
+    -   `evaluateXPath.ALL_RESULTS_TYPE` Returns the result of the query, can be anything depending
+        on the query. This will always be an array, and the result can be mixed: contain both nodes
+        and strings for example.
     -   `evaluateXPath.NUMBER_TYPE` Resolve to a `number`, like count((1,2,3)) resolves to 3.
     -   `evaluateXPath.STRING_TYPE` Resolve to a `string`, like //someElement[1] resolves to the text
         content of the first someElement.
@@ -57,6 +58,10 @@ evaluateXPathToStrings(xpathExpression, contextNode, domFacade, variables, optio
     -   `evaluateXPath.ARRAY_TYPE` Resolve to an array `[]`.
     -   `evaluateXPath.ASYNC_ITERATOR_TYPE`
     -   `evaluateXPath.NUMBERS_TYPE` Resolve to an array of numbers `number[]`.
+    -   `evaluateXPath.ANY_TYPE` Returns the result of the query, can be anything depending on the
+        query. Note that the return type is determined dynamically, not statically: XPaths returning
+        empty sequences will return empty arrays and not null, like one might expect.
+		This is deprecated, use `evaluateXPath.ALL_RESULTS_TYPE` instead, since that is more predictable.
 -   `options` `<Object>` Options used to modify the behavior. The following options are available:
     -   `namespaceResolver` `<function(string):string?>` By default, the namespaces in scope of the
         context item (if it is a node) are used. This is fine for most queries if you can assume how

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -46,10 +46,19 @@ export type EvaluateXPath = {
 	): IReturnTypes<TNode>[TReturnType];
 
 	/**
+	 * Resolve to all results, adapted to JavaScript values
+	 */
+	ALL_RESULTS_TYPE: ReturnType.ALL_RESULTS;
+
+	/**
 	 * Returns the result of the query, can be anything depending on the
 	 * query. Note that the return type is determined dynamically, not
 	 * statically: XPaths returning empty sequences will return empty
 	 * arrays and not null, like one might expect.
+	 *
+	 * @deprecated
+	 *
+	 * For predictable results, use the ALL_RESULTS return type
 	 */
 	ANY_TYPE: ReturnType.ANY;
 
@@ -220,38 +229,40 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 };
 
 Object.assign(evaluateXPath, {
+	ALL_RESULTS_TYPE: ReturnType.ALL_RESULTS,
 	ANY_TYPE: ReturnType.ANY,
-	NUMBER_TYPE: ReturnType.NUMBER,
-	STRING_TYPE: ReturnType.STRING,
-	BOOLEAN_TYPE: ReturnType.BOOLEAN,
-	NODES_TYPE: ReturnType.NODES,
-	FIRST_NODE_TYPE: ReturnType.FIRST_NODE,
-	STRINGS_TYPE: ReturnType.STRINGS,
-	MAP_TYPE: ReturnType.MAP,
 	ARRAY_TYPE: ReturnType.ARRAY,
 	ASYNC_ITERATOR_TYPE: ReturnType.ASYNC_ITERATOR,
+	BOOLEAN_TYPE: ReturnType.BOOLEAN,
+	FIRST_NODE_TYPE: ReturnType.FIRST_NODE,
+	MAP_TYPE: ReturnType.MAP,
+	NODES_TYPE: ReturnType.NODES,
 	NUMBERS_TYPE: ReturnType.NUMBERS,
-	XQUERY_UPDATE_3_1_LANGUAGE: Language.XQUERY_UPDATE_3_1_LANGUAGE,
-	XQUERY_3_1_LANGUAGE: Language.XQUERY_3_1_LANGUAGE,
+	NUMBER_TYPE: ReturnType.NUMBER,
+	STRINGS_TYPE: ReturnType.STRINGS,
+	STRING_TYPE: ReturnType.STRING,
 	XPATH_3_1_LANGUAGE: Language.XPATH_3_1_LANGUAGE,
+	XQUERY_3_1_LANGUAGE: Language.XQUERY_3_1_LANGUAGE,
+	XQUERY_UPDATE_3_1_LANGUAGE: Language.XQUERY_UPDATE_3_1_LANGUAGE,
 });
 
 // Set all of the properties a second time to prevent closure renames
 Object.assign(evaluateXPath, {
+	['ALL_RESULTS_TYPE']: ReturnType.ALL_RESULTS,
 	['ANY_TYPE']: ReturnType.ANY,
-	['NUMBER_TYPE']: ReturnType.NUMBER,
-	['STRING_TYPE']: ReturnType.STRING,
-	['BOOLEAN_TYPE']: ReturnType.BOOLEAN,
-	['NODES_TYPE']: ReturnType.NODES,
-	['FIRST_NODE_TYPE']: ReturnType.FIRST_NODE,
-	['STRINGS_TYPE']: ReturnType.STRINGS,
-	['MAP_TYPE']: ReturnType.MAP,
 	['ARRAY_TYPE']: ReturnType.ARRAY,
 	['ASYNC_ITERATOR_TYPE']: ReturnType.ASYNC_ITERATOR,
+	['BOOLEAN_TYPE']: ReturnType.BOOLEAN,
+	['FIRST_NODE_TYPE']: ReturnType.FIRST_NODE,
+	['MAP_TYPE']: ReturnType.MAP,
+	['NODES_TYPE']: ReturnType.NODES,
 	['NUMBERS_TYPE']: ReturnType.NUMBERS,
-	['XQUERY_UPDATE_3_1_LANGUAGE']: Language.XQUERY_UPDATE_3_1_LANGUAGE,
-	['XQUERY_3_1_LANGUAGE']: Language.XQUERY_3_1_LANGUAGE,
+	['NUMBER_TYPE']: ReturnType.NUMBER,
+	['STRINGS_TYPE']: ReturnType.STRINGS,
+	['STRING_TYPE']: ReturnType.STRING,
 	['XPATH_3_1_LANGUAGE']: Language.XPATH_3_1_LANGUAGE,
+	['XQUERY_3_1_LANGUAGE']: Language.XQUERY_3_1_LANGUAGE,
+	['XQUERY_UPDATE_3_1_LANGUAGE']: Language.XQUERY_UPDATE_3_1_LANGUAGE,
 });
 
 export default evaluateXPath as EvaluateXPath;

--- a/src/parsing/convertXDMReturnValue.ts
+++ b/src/parsing/convertXDMReturnValue.ts
@@ -30,7 +30,7 @@ export enum ReturnType {
 	 *
 	 * If the result is the empty sequence, an empty array is returned
 	 *
-	 * If the result is multiple items, an array with those items is returned. Nodes are rutned as-is, but attribute nodes are atomized.
+	 * If the result is multiple items, an array with those items is returned. Nodes are returned as-is, but attribute nodes are atomized.
 	 *
 	 * Note that this is usually _not_ what you'd expect, and may cause bugs to show up when you
 	 * don't expect. Use ALL_RESULTS to get all results, always as an array, without special

--- a/test/specs/parsing/evaluateXPath.tests.ts
+++ b/test/specs/parsing/evaluateXPath.tests.ts
@@ -95,17 +95,17 @@ describe('evaluateXPath', () => {
 
 	describe('ALL_RESULTS: the better ANY', () => {
 		it('Keeps booleans booleans', () =>
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath('true()', documentNode, domFacade, {}, ReturnType.ALL_RESULTS),
 				[true]
 			));
 		it('Keeps numbers numbers', () =>
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath('1', documentNode, domFacade, {}, ReturnType.ALL_RESULTS),
 				[1]
 			));
 		it('Keeps mixed sequences mixed', () =>
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath(
 					'1,true(),"test",.',
 					documentNode,
@@ -116,19 +116,19 @@ describe('evaluateXPath', () => {
 				[1, true, 'test', documentNode]
 			));
 		it('Keeps strings strings', () =>
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath('"string"', documentNode, domFacade, {}, ReturnType.ALL_RESULTS),
 				['string']
 			));
 		it('Keeps nodes nodes', () =>
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath('.', documentNode, domFacade, {}, ReturnType.ALL_RESULTS),
 				[documentNode]
 			));
 		it('Keeps attributes attributes', () => {
 			const tmp = documentNode.createElement('tmp');
 			tmp.setAttribute('class', 'value');
-			chai.assert.deepEqual(
+			chai.assert.sameMembers(
 				evaluateXPath('@class', tmp, domFacade, {}, ReturnType.ALL_RESULTS),
 				[tmp.getAttributeNode('class')]
 			);


### PR DESCRIPTION
The ANY result type is annoying. It returns a single node, empty arrays, filled arrays, objects,
etcetera.

This was a mistake from the beginning on. While it is very cool to have an XPath 'just work', it
causes bugs and the ugly pattern `if (!Array.isArray(result)) {result = [result])`. Also, attribute
nodes are atomized.

No longer! Just use the ALL_RESULTS type that does _what you expect_. This also deprecates the ANY
result type. FontoXPath 4.0 _will_ drop support for ANY!