### PR TITLE
Functions base + (local-)name support for JSCodegen

### DIFF
--- a/src/jsCodegen/compileAstToJavaScript.ts
+++ b/src/jsCodegen/compileAstToJavaScript.ts
@@ -24,7 +24,7 @@ function emitEvaluationToNodes(
 ): PartialCompilationResult {
 	const [valueCode, valueCodeType] = getCompiledValueCode(identifier, generatedCodeType);
 	if (valueCodeType.type !== GeneratedCodeBaseType.Iterator) {
-		return acceptAst(`return [];`, { type: GeneratedCodeBaseType.Statement });
+		return rejectAst('Return type was not an iterator');
 	}
 
 	return acceptAst(
@@ -141,7 +141,6 @@ function wrapCompiledCode(code: string, shouldUseContextItem: boolean): string {
 
 	finalCode += code + `}`;
 	finalCode += '\n//# sourceURL=generated.js';
-
 	return finalCode;
 }
 

--- a/src/jsCodegen/emitBaseExpression.ts
+++ b/src/jsCodegen/emitBaseExpression.ts
@@ -1,11 +1,18 @@
 import { IAST } from '../parsing/astHelper';
 import { CodeGenContext } from './CodeGenContext';
 import { emitCompareExpr } from './emitCompare';
+import { emitFunctionCallExpr } from './emitFunctionCallExpr';
 import { emitStringLiteralExpression } from './emitLiterals';
 import { emitAndExpr, emitOrExpr } from './emitLogicalExpr';
-import { baseExprAstNodes } from './emitOperand';
+import { baseExprAstNodes, baseExpressions } from './emitOperand';
 import { emitPathExpr } from './emitPathExpr';
-import { FunctionIdentifier, PartialCompilationResult, rejectAst } from './JavaScriptCompiledXPath';
+import {
+	acceptAst,
+	FunctionIdentifier,
+	GeneratedCodeBaseType,
+	PartialCompilationResult,
+	rejectAst,
+} from './JavaScriptCompiledXPath';
 
 /**
  * Compile AST to base expression wrapped in a function named as the given identifier.
@@ -38,7 +45,7 @@ export function emitBaseExpr(
 		case baseExprAstNodes.LESS_THAN_OR_EQUAL_OP:
 		case baseExprAstNodes.LESS_THAN_OP:
 		case baseExprAstNodes.GREATER_THAN_OR_EQUAL_OP:
-		case baseExprAstNodes.GREAtER_THAN_OP:
+		case baseExprAstNodes.GREATER_THAN_OP:
 		// valueCompare
 		case baseExprAstNodes.EQ_OP:
 		case baseExprAstNodes.NE_OP:
@@ -51,6 +58,8 @@ export function emitBaseExpr(
 		case baseExprAstNodes.NODE_BEFORE_OP:
 		case baseExprAstNodes.NODE_AFTER_OP:
 			return emitCompareExpr(ast, identifier, staticContext, name);
+		case baseExprAstNodes.FUNCTION_CALL_EXPR:
+			return emitFunctionCallExpr(ast, identifier, staticContext);
 		default:
 			return rejectAst(`Unsupported: the base expression '${name}'.`);
 	}

--- a/src/jsCodegen/emitFunctionCallExpr.ts
+++ b/src/jsCodegen/emitFunctionCallExpr.ts
@@ -1,0 +1,135 @@
+import astHelper, { IAST } from '../parsing/astHelper';
+import { CodeGenContext } from './CodeGenContext';
+import {
+	acceptAst,
+	FunctionIdentifier,
+	GeneratedCodeBaseType,
+	getCompiledValueCode,
+	IAstRejected,
+	PartialCompilationResult,
+	PartiallyCompiledAstAccepted,
+	rejectAst,
+} from './JavaScriptCompiledXPath';
+
+const supportedFunctions: Record<
+	string,
+	(
+		ast: IAST,
+		identifier: FunctionIdentifier,
+		staticContext: CodeGenContext
+	) => PartialCompilationResult
+> = {
+	'local-name': emitLocalNameFunction,
+	name: emitNameFunction,
+};
+
+function emitArgument(
+	ast: IAST,
+	staticContext: CodeGenContext,
+	identifier: FunctionIdentifier
+): PartialCompilationResult {
+	const baseExpr = staticContext.emitBaseExpr(ast, identifier, staticContext);
+
+	if (!baseExpr.isAstAccepted) {
+		return baseExpr;
+	}
+
+	return acceptAst(`${identifier}`, baseExpr.generatedCodeType, [baseExpr.code]);
+}
+
+export function emitFunctionCallExpr(
+	ast: IAST,
+	identifier: FunctionIdentifier,
+	staticContext: CodeGenContext
+): PartialCompilationResult {
+	const functionName = astHelper.getTextContent(astHelper.getFirstChild(ast, 'functionName'));
+
+	if (supportedFunctions[functionName] !== undefined) {
+		return supportedFunctions[functionName](ast, identifier, staticContext);
+	}
+
+	return rejectAst(`Unsupported function: ${functionName}`);
+}
+
+const contextItemCheck = `if (contextItem === undefined || contextItem === null) {
+	throw new Error('XPDY0002: The function which was called depends on dynamic context, which is absent.');
+}`;
+
+function createLocalNameGetter(itemName: string) {
+	return `(${itemName}.localName || ${itemName}.target || '')`;
+}
+
+function createNameGetter(itemName: string) {
+	return `(((${itemName}.prefix || '').length !== 0 ? ${itemName}.prefix + ':' : '') 
+		+ (${itemName}.localName || ${itemName}.target || ''))`;
+}
+
+function emitSpecificNameFunction(
+	ast: IAST,
+	identifier: FunctionIdentifier,
+	staticContext: CodeGenContext,
+	nameGetterFunction: (itemName: string) => string,
+	functionName: string
+): PartialCompilationResult {
+	const argsAst = astHelper.getFirstChild(ast, 'arguments');
+	let code = '';
+	if (argsAst.length === 1) {
+		// No args
+		code = `function ${identifier}(contextItem) {
+			${contextItemCheck}
+			return ${nameGetterFunction('contextItem')};
+		}`;
+	} else if (argsAst.length === 2) {
+		// One arg
+		const innerAst = argsAst[1] as IAST;
+		const emittedArg = emitArgument(innerAst, staticContext, 'arg');
+		// Special handling if context item is passed in
+		if (innerAst[0] === 'contextItemExpr') {
+			code = `function ${identifier}(contextItem) {
+				${contextItemCheck}
+				return ${nameGetterFunction('contextItem')};
+			}`;
+		} else {
+			if (!emittedArg.isAstAccepted) {
+				return emittedArg;
+			}
+
+			code = `function ${identifier}(contextItem) {
+				${emittedArg.variables}
+				const value = ${getCompiledValueCode(emittedArg.code, emittedArg.generatedCodeType)[0]};
+				const childElement = value.next().value;
+				return (value.done ? "" : ${nameGetterFunction('childElement')});
+			}`;
+		}
+	} else {
+		// Two or more args
+		return rejectAst(`Incorrect arg count for ${functionName} function`);
+	}
+
+	return acceptAst(code, {
+		type: GeneratedCodeBaseType.Function,
+		returnType: { type: GeneratedCodeBaseType.Value },
+	});
+}
+
+function emitNameFunction(
+	ast: IAST,
+	identifier: FunctionIdentifier,
+	staticContext: CodeGenContext
+): PartialCompilationResult {
+	return emitSpecificNameFunction(ast, identifier, staticContext, createNameGetter, 'name()');
+}
+
+function emitLocalNameFunction(
+	ast: IAST,
+	identifier: FunctionIdentifier,
+	staticContext: CodeGenContext
+): PartialCompilationResult {
+	return emitSpecificNameFunction(
+		ast,
+		identifier,
+		staticContext,
+		createLocalNameGetter,
+		'local-name()'
+	);
+}

--- a/src/jsCodegen/emitOperand.ts
+++ b/src/jsCodegen/emitOperand.ts
@@ -22,8 +22,7 @@ export const baseExprAstNodes = {
 	LESS_THAN_OR_EQUAL_OP: 'lessThanOrEqualOp',
 	LESS_THAN_OP: 'lessThanOp',
 	GREATER_THAN_OR_EQUAL_OP: 'greaterThanOrEqualOp',
-	GREAtER_THAN_OP: 'greaterThanOp',
-	// valueCompare
+	GREATER_THAN_OP: 'greaterThanOp',
 	EQ_OP: 'eqOp',
 	NE_OP: 'neOp',
 	LT_OP: 'ltOp',
@@ -31,9 +30,9 @@ export const baseExprAstNodes = {
 	GT_OP: 'gtOp',
 	GE_OP: 'geOp',
 	IS_OP: 'isOp',
-	// nodeCompare
 	NODE_BEFORE_OP: 'nodeBeforeOp',
 	NODE_AFTER_OP: 'nodeAfterOp',
+	FUNCTION_CALL_EXPR: 'functionCallExpr',
 };
 
 export const baseExpressions = Object.values(baseExprAstNodes);

--- a/test/specs/expressions/jsCodegen/compare.tests.ts
+++ b/test/specs/expressions/jsCodegen/compare.tests.ts
@@ -17,7 +17,7 @@ describe('compare tests', () => {
 
 		chai.assert.throws(
 			() => evaluateXPathWithJsCodegen(query, node, null, ReturnType.BOOLEAN),
-			'Unsupported: a base expression used with an operand.'
+			'Unsupported function: true'
 		);
 
 		chai.assert.equal(evaluateXPathToBoolean(query, node), true);


### PR DESCRIPTION
Basic support for functions in JSCodegen. Currently only name() and local-name() are properly supported.