### PR TITLE
Fix `fn:outermost` called with a `descendant` axis wrong results

### DIFF
--- a/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
+++ b/src/expressions/dataTypes/Sequences/IteratorBackedSequence.ts
@@ -65,7 +65,7 @@ export default class IteratorBackedSequence implements ISequence {
 					}
 
 					i++;
-					value = iterator.next(hint);
+					value = iterator.next(IterationHint.NONE);
 				}
 				return value;
 			},

--- a/test/specs/parsing/functions/functions.node.tests.ts
+++ b/test/specs/parsing/functions/functions.node.tests.ts
@@ -169,6 +169,24 @@ return $node/root() = $element`,
 			);
 		});
 
+		it('returns the top level nodes if the set only contains nephews', () => {
+			jsonMlMapper.parse(
+				[
+					'root',
+					['child', ['descendant', { pos: 'first' }]],
+					['child', ['descendant', { pos: 'last' }]],
+				],
+				documentNode
+			);
+			chai.assert.deepEqual(
+				evaluateXPathToStrings(
+					'(descendant::descendant => outermost())!@pos',
+					documentNode
+				),
+				['first', 'last']
+			);
+		});
+
 		it('sorts the passed sequence', () => {
 			jsonMlMapper.parse(['root', ['child1'], ['child2', ['descendant']]], documentNode);
 			chai.assert.deepEqual(


### PR DESCRIPTION
This will fix #434 