### PR TITLE
Implementation of distinct-values

### DIFF
--- a/src/expressions/functions/builtInFunctions_sequences.ts
+++ b/src/expressions/functions/builtInFunctions_sequences.ts
@@ -241,7 +241,7 @@ const fnDistinctValues: FunctionDefinitionType = (
 	const xs = atomize(sequence, executionParameters).getAllValues();
 	const equals = (x: Value, y: Value): boolean =>
 		anyAtomicTypeDeepEqual(dynamicContext, executionParameters, _staticContext, x, y);
-	return sequenceFactory.create(xs).filter((x, i) => xs.slice(0, i).every((y) => ! equals(x, y)));
+	return sequenceFactory.create(xs).filter((x, i) => xs.slice(0, i).every((y) => !equals(x, y)));
 };
 
 const fnIndexOf: FunctionDefinitionType = (
@@ -792,7 +792,9 @@ const declarations: BuiltinDeclarationType[] = [
 	},
 
 	{
-		argumentTypes: [{ type: ValueType.XSANYATOMICTYPE, mult: SequenceMultiplicity.ZERO_OR_MORE }],
+		argumentTypes: [
+			{ type: ValueType.XSANYATOMICTYPE, mult: SequenceMultiplicity.ZERO_OR_MORE },
+		],
 		callFunction: fnDistinctValues,
 		localName: 'distinct-values',
 		namespaceURI: BUILT_IN_NAMESPACE_URIS.FUNCTIONS_NAMESPACE_URI,
@@ -802,7 +804,7 @@ const declarations: BuiltinDeclarationType[] = [
 	{
 		argumentTypes: [
 			{ type: ValueType.XSANYATOMICTYPE, mult: SequenceMultiplicity.ZERO_OR_MORE },
-			{ type: ValueType.XSSTRING, mult: SequenceMultiplicity.EXACTLY_ONE }
+			{ type: ValueType.XSSTRING, mult: SequenceMultiplicity.EXACTLY_ONE },
 		],
 		callFunction() {
 			throw new Error('FOCH0002: No collations are supported');

--- a/src/expressions/functions/builtInFunctions_sequences_deepEqual.ts
+++ b/src/expressions/functions/builtInFunctions_sequences_deepEqual.ts
@@ -113,6 +113,18 @@ export function anyAtomicTypeDeepEqual(
 	) {
 		return equal(item1.value, item2.value);
 	}
+
+	if (
+		(isSubtypeOf(item1.type, ValueType.XSYEARMONTHDURATION) ||
+			isSubtypeOf(item1.type, ValueType.XSDAYTIMEDURATION) ||
+			isSubtypeOf(item1.type, ValueType.XSDURATION)) &&
+		(isSubtypeOf(item2.type, ValueType.XSYEARMONTHDURATION) ||
+			isSubtypeOf(item2.type, ValueType.XSDAYTIMEDURATION) ||
+			isSubtypeOf(item2.type, ValueType.XSDAYTIMEDURATION))
+	) {
+		return item1.value.equals(item2.value);
+	}
+
 	return item1.value === item2.value;
 }
 

--- a/src/expressions/functions/builtInFunctions_sequences_deepEqual.ts
+++ b/src/expressions/functions/builtInFunctions_sequences_deepEqual.ts
@@ -57,7 +57,7 @@ function filterElementAndTextNodes(node: NodePointer, domFacade: DomFacade) {
 	return nodeType === NODE_TYPES.ELEMENT_NODE || nodeType === NODE_TYPES.TEXT_NODE;
 }
 
-function anyAtomicTypeDeepEqual(
+export function anyAtomicTypeDeepEqual(
 	_dynamicContext: DynamicContext,
 	_executionParameters: ExecutionParameters,
 	_staticContext: StaticContext,

--- a/test/assets/runnableTestSets.csv
+++ b/test/assets/runnableTestSets.csv
@@ -67,7 +67,7 @@ fn-days-from-duration,true
 fn-deep-equal,true
 fn-default-collation,false
 fn-default-language,false
-fn-distinct-values,false
+fn-distinct-values,true
 fn-doc,false
 fn-doc-available,false
 fn-document-uri,false

--- a/test/assets/unrunnableTestCases.csv
+++ b/test/assets/unrunnableTestCases.csv
@@ -4005,3 +4005,31 @@ fo-test-array-subarray-006,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-subarray-007,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-fold-right-003,AssertionError: Expected XPath          array:fold-right([1,2,3], [], function($x, $y){[$x, $y]})        to (deep equally) resolve to [1, [2, [3, []]]]: expected false to be true
 fo-test-array-sort-002,Error: XPST0017: Function array:sort with arity of 3 not registered. Did you mean "Q{http://www.w3.org/2005/xpath-functions/array}sort (array(*))", "Q{http://www.w3.org/2001/XMLSchema}short (xs:anyAtomicType?)" or "Q{http://www.w3.org/2005/xpath-functions/math}sqrt (xs:double?)"?
+fn-distinct-valuesintg1args-1,Error: FOCA0003: can not cast -999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesintg1args-2,Error: FOCA0003: can not cast 830993497117024304 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesintg1args-3,Error: FOCA0003: can not cast 999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valueslng1args-1,Error: FOCA0003: can not cast -92233720368547758 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valueslng1args-2,Error: FOCA0003: can not cast -47175562203048468 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valueslng1args-3,Error: FOCA0003: can not cast 92233720368547758 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnint1args-1,Error: FOCA0003: can not cast -999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnint1args-2,Error: FOCA0003: can not cast -297014075999096793 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuespint1args-2,Error: FOCA0003: can not cast 52704602390610033 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuespint1args-3,Error: FOCA0003: can not cast 999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesulng1args-2,Error: FOCA0003: can not cast 130747108607674654 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesulng1args-3,Error: FOCA0003: can not cast 184467440737095516 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnpi1args-1,Error: FOCA0003: can not cast -999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnpi1args-2,Error: FOCA0003: can not cast -475688437271870490 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnni1args-2,Error: FOCA0003: can not cast 303884545991464527 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-valuesnni1args-3,Error: FOCA0003: can not cast 999999999999999999 to xs:integer, it is out of bounds for JavaScript numbers.
+fn-distinct-values-mixed-args-005,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-006,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-009,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-010,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-011,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-018,AssertionError: Skipped test, it was a assert-permutation
+fn-distinct-values-mixed-args-032,AssertionError: Skipped test, it was a assert-permutation
+K-SeqDistinctValuesFunc-4,Error: FOCH0002: No collations are supported
+fn-distinct-values-2,AssertionError: Skipped test, it was a assert-permutation
+cbcl-distinct-values-002b,Error: Casting to xs:QName is not implemented.
+cbcl-distinct-values-003,Error: XPST0017: Function adjust-dateTime-to-timezone with arity of 1 not registered. Did you mean "Q{test}custom-dateTime-function ()"?
+cbcl-distinct-values-007,Error: XPST0017: Function adjust-time-to-timezone with arity of 2 not registered. No similar functions found.


### PR DESCRIPTION
* The implementation keeps the first occurrence in a sequence – this is not demanded by the specification, but some tests are written that way.
* The implementation uses a naive nested loop; a more optimized version would require a concept of hash values or similar to partition elements into buckets – I did not find something like that in the implementation yet and decided not to dive into such a fundamental issue of runtime presentation.
* There seems to be a weakness in comparing durations, which I will address in a separate pull request.