### PR TITLE
README.md: remove mention of obsolete evaluateUpdatingExpressionSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ declare %public %updating function my-custom-namespace:do-something ($ele as ele
 `);
 // At some point:
 const contextNode = null;
-const pendingUpdatesAndXdmValue = evaluateUpdatingExpressionSync(
+const pendingUpdatesAndXdmValue = evaluateUpdatingExpression(
 	'ns:do-something(.)',
 	contextNode,
 	null,


### PR DESCRIPTION
I notice that this function still exists! But I don’t think it was meant to
be used in this example code.