### PR TITLE
Make fontoxpath:evaluate accept an AST as well as a string

### DIFF
--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -1,28 +1,28 @@
-import convertXmlToAst from '../../parsing/convertXmlToAst';
+import { ElementNodePointer } from 'src/domClone/Pointer';
 import { printAndRethrowError } from '../../evaluationUtils/printAndRethrowError';
 import astHelper, { IAST } from '../../parsing/astHelper';
 import compileAstToExpression from '../../parsing/compileAstToExpression';
+import convertXmlToAst from '../../parsing/convertXmlToAst';
 import parseExpression from '../../parsing/parseExpression';
 import processProlog from '../../parsing/processProlog';
 import annotateAst from '../../typeInference/annotateAST';
 import { AnnotationContext } from '../../typeInference/AnnotationContext';
 import createAtomicValue from '../dataTypes/createAtomicValue';
+import ISequence from '../dataTypes/ISequence';
 import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import MapValue from '../dataTypes/MapValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
 import Value, { SequenceMultiplicity, ValueType, valueTypeToString } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
+import ExecutionParameters from '../ExecutionParameters';
 import ExecutionSpecificStaticContext from '../ExecutionSpecificStaticContext';
 import { BUILT_IN_NAMESPACE_URIS } from '../staticallyKnownNamespaces';
 import StaticContext from '../StaticContext';
 import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
 import { IIterator, IterationHint } from '../util/iterators';
+import { errXPTY0004 } from '../XPathErrors';
 import { BuiltinDeclarationType } from './builtInFunctions';
 import FunctionDefinitionType from './FunctionDefinitionType';
-import { errXPTY0004 } from '../XPathErrors';
-import { ElementNodePointer } from 'src/domClone/Pointer';
-import ExecutionParameters from '../ExecutionParameters';
-import ISequence from '../dataTypes/ISequence';
 
 function createAstFromValue(queryValue: Value, debug: boolean): IAST {
 	if (isSubtypeOf(queryValue.type, ValueType.XSSTRING)) {
@@ -128,7 +128,7 @@ function buildResultIterator(
 	try {
 		return {
 			resultIterator: selector.evaluate(innerDynamicContext, executionParameters).value,
-			queryValue: queryValue,
+			queryValue,
 		};
 	} catch (error) {
 		printAndRethrowError(queryValue.value, error);

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -1,4 +1,4 @@
-import { ElementNodePointer } from 'src/domClone/Pointer';
+import { ElementNodePointer } from '../../domClone/Pointer';
 import { printAndRethrowError } from '../../evaluationUtils/printAndRethrowError';
 import astHelper, { IAST } from '../../parsing/astHelper';
 import compileAstToExpression from '../../parsing/compileAstToExpression';

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -1,14 +1,16 @@
+import convertXmlToAst from '../../parsing/convertXmlToAst';
 import { printAndRethrowError } from '../../evaluationUtils/printAndRethrowError';
-import astHelper from '../../parsing/astHelper';
+import astHelper, { IAST } from '../../parsing/astHelper';
 import compileAstToExpression from '../../parsing/compileAstToExpression';
 import parseExpression from '../../parsing/parseExpression';
 import processProlog from '../../parsing/processProlog';
 import annotateAst from '../../typeInference/annotateAST';
 import { AnnotationContext } from '../../typeInference/AnnotationContext';
 import createAtomicValue from '../dataTypes/createAtomicValue';
+import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import MapValue from '../dataTypes/MapValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import Value, { SequenceMultiplicity, ValueType } from '../dataTypes/Value';
+import Value, { SequenceMultiplicity, ValueType, valueTypeToString } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionSpecificStaticContext from '../ExecutionSpecificStaticContext';
 import { BUILT_IN_NAMESPACE_URIS } from '../staticallyKnownNamespaces';
@@ -17,6 +19,121 @@ import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
 import { IIterator, IterationHint } from '../util/iterators';
 import { BuiltinDeclarationType } from './builtInFunctions';
 import FunctionDefinitionType from './FunctionDefinitionType';
+import { errXPTY0004 } from '../XPathErrors';
+import { ElementNodePointer } from 'src/domClone/Pointer';
+import ExecutionParameters from '../ExecutionParameters';
+import ISequence from '../dataTypes/ISequence';
+
+function createAstFromValue(queryValue: Value, debug: boolean): IAST {
+	if (isSubtypeOf(queryValue.type, ValueType.XSSTRING)) {
+		return parseExpression(queryValue.value as string, {
+			allowXQuery: false,
+			debug,
+		});
+	}
+
+	if (isSubtypeOf(queryValue.type, ValueType.ELEMENT)) {
+		const nodePointer: ElementNodePointer = queryValue.value;
+
+		try {
+			return convertXmlToAst(nodePointer.node);
+		} catch (error) {
+			throw errXPTY0004(
+				'The XML structure passed as an XQueryX program was not valid XQueryX'
+			);
+		}
+	}
+
+	throw errXPTY0004(
+		`Unable to convert selector argument of type ${valueTypeToString(
+			queryValue.type
+		)} to either an ${valueTypeToString(ValueType.XSSTRING)} or an ${valueTypeToString(
+			ValueType.ELEMENT
+		)} representing an XQueryX program while calling 'fontoxpath:evaluate'`
+	);
+}
+
+function buildResultIterator(
+	query: ISequence,
+	args: ISequence,
+	staticContext: StaticContext,
+	executionParameters: ExecutionParameters
+): { queryValue: Value; resultIterator: IIterator<Value> } {
+	const queryValue = query.first();
+	const variables = (args.first() as MapValue).keyValuePairs.reduce((expandedArgs, arg) => {
+		expandedArgs[arg.key.value] = createDoublyIterableSequence(arg.value());
+		return expandedArgs;
+	}, Object.create(null));
+
+	// Take off the context item
+	const contextItemSequence = variables['.'] ? variables['.']() : sequenceFactory.empty();
+	delete variables['.'];
+
+	const executionSpecificStaticContext = new ExecutionSpecificStaticContext(
+		(prefix) => staticContext.resolveNamespace(prefix),
+		Object.keys(variables).reduce((vars: { [s: string]: string }, varName) => {
+			vars[varName] = varName;
+			return vars;
+		}, {}),
+		BUILT_IN_NAMESPACE_URIS.FUNCTIONS_NAMESPACE_URI,
+		(lexicalName, arity) => staticContext.resolveFunctionName(lexicalName, arity)
+	);
+	const innerStaticContext = new StaticContext(executionSpecificStaticContext);
+
+	const ast = createAstFromValue(queryValue, executionParameters.debug);
+
+	if (executionParameters.annotateAst) {
+		annotateAst(ast, new AnnotationContext(innerStaticContext));
+	}
+
+	const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);
+	if (prolog) {
+		processProlog(prolog, innerStaticContext);
+	}
+	const queryBodyContents = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
+
+	const selector = compileAstToExpression(queryBodyContents, {
+		allowUpdating: false,
+		allowXQuery: true,
+	});
+
+	try {
+		selector.performStaticEvaluation(innerStaticContext);
+	} catch (error) {
+		printAndRethrowError(queryValue.value, error);
+	}
+
+	const variableBindings = Object.keys(variables).reduce((variablesByBindingKey, varName) => {
+		variablesByBindingKey[executionSpecificStaticContext.lookupVariable(null, varName)] =
+			variables[varName];
+		return variablesByBindingKey;
+	}, Object.create(null));
+
+	const context = contextItemSequence.isEmpty()
+		? {
+				contextItem: null,
+				contextItemIndex: -1,
+				contextSequence: contextItemSequence,
+				variableBindings,
+		  }
+		: {
+				contextItem: contextItemSequence.first(),
+				contextItemIndex: 0,
+				contextSequence: contextItemSequence,
+				variableBindings,
+		  };
+
+	const innerDynamicContext = new DynamicContext(context);
+
+	try {
+		return {
+			resultIterator: selector.evaluate(innerDynamicContext, executionParameters).value,
+			queryValue: queryValue,
+		};
+	} catch (error) {
+		printAndRethrowError(queryValue.value, error);
+	}
+}
 
 const fontoxpathEvaluate: FunctionDefinitionType = (
 	_dynamicContext,
@@ -26,107 +143,22 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 	args
 ) => {
 	let resultIterator: IIterator<Value>;
-	let queryString: string;
+	let queryValue: Value;
 	return sequenceFactory.create({
 		next: () => {
 			if (!resultIterator) {
-				const queryValue = query.value.next(IterationHint.NONE);
-				queryString = queryValue.value.value;
-				const variables = (args.first() as MapValue).keyValuePairs.reduce(
-					(expandedArgs, arg) => {
-						expandedArgs[arg.key.value] = createDoublyIterableSequence(arg.value());
-						return expandedArgs;
-					},
-					Object.create(null)
-				);
-
-				// Take off the context item
-				const contextItemSequence = variables['.']
-					? variables['.']()
-					: sequenceFactory.empty();
-				delete variables['.'];
-
-				const executionSpecificStaticContext = new ExecutionSpecificStaticContext(
-					(prefix) => staticContext.resolveNamespace(prefix),
-					Object.keys(variables).reduce((vars: { [s: string]: string }, varName) => {
-						vars[varName] = varName;
-						return vars;
-					}, {}),
-					BUILT_IN_NAMESPACE_URIS.FUNCTIONS_NAMESPACE_URI,
-					(lexicalName, arity) => staticContext.resolveFunctionName(lexicalName, arity)
-				);
-				const innerStaticContext = new StaticContext(executionSpecificStaticContext);
-
-				const ast = parseExpression(queryString, {
-					allowXQuery: false,
-					debug: executionParameters.debug,
-				});
-
-				if (executionParameters.annotateAst) {
-					annotateAst(ast, new AnnotationContext(innerStaticContext));
-				}
-
-				const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);
-				if (prolog) {
-					processProlog(prolog, innerStaticContext);
-				}
-				const queryBodyContents = astHelper.followPath(ast, [
-					'mainModule',
-					'queryBody',
-					'*',
-				]);
-
-				const selector = compileAstToExpression(queryBodyContents, {
-					allowUpdating: false,
-					allowXQuery: true,
-				});
-
-				try {
-					selector.performStaticEvaluation(innerStaticContext);
-				} catch (error) {
-					printAndRethrowError(queryString, error);
-				}
-
-				const variableBindings = Object.keys(variables).reduce(
-					(variablesByBindingKey, varName) => {
-						variablesByBindingKey[
-							executionSpecificStaticContext.lookupVariable(null, varName)
-						] = variables[varName];
-						return variablesByBindingKey;
-					},
-					Object.create(null)
-				);
-
-				const context = contextItemSequence.isEmpty()
-					? {
-							contextItem: null,
-							contextItemIndex: -1,
-							contextSequence: contextItemSequence,
-							variableBindings,
-					  }
-					: {
-							contextItem: contextItemSequence.first(),
-							contextItemIndex: 0,
-							contextSequence: contextItemSequence,
-							variableBindings,
-					  };
-
-				const innerDynamicContext = new DynamicContext(context);
-
-				try {
-					resultIterator = selector.evaluate(
-						innerDynamicContext,
-						executionParameters
-					).value;
-				} catch (error) {
-					printAndRethrowError(queryString, error);
-				}
+				({ resultIterator, queryValue } = buildResultIterator(
+					query,
+					args,
+					staticContext,
+					executionParameters
+				));
 			}
 
 			try {
 				return resultIterator.next(IterationHint.NONE);
 			} catch (error) {
-				printAndRethrowError(queryString, error);
+				printAndRethrowError(queryValue.value, error);
 			}
 		},
 	});
@@ -144,7 +176,7 @@ const fontoxpathVersion: FunctionDefinitionType = () => {
 const declarations: BuiltinDeclarationType[] = [
 	{
 		argumentTypes: [
-			{ type: ValueType.XSSTRING, mult: SequenceMultiplicity.EXACTLY_ONE },
+			{ type: ValueType.ITEM, mult: SequenceMultiplicity.EXACTLY_ONE },
 			{ type: ValueType.MAP, mult: SequenceMultiplicity.EXACTLY_ONE },
 		],
 		callFunction: fontoxpathEvaluate,

--- a/test/specs/parsing/functions/functions.fontoxpath.tests.ts
+++ b/test/specs/parsing/functions/functions.fontoxpath.tests.ts
@@ -138,6 +138,80 @@ describe('extension functions', () => {
 				1000
 			));
 
+		it('also allows XQueryX programs to be evaluated', () =>
+			chai.assert.equal(
+				evaluateXPathToNumber(
+					`fontoxpath:evaluate(<xqx:module xmlns:xqx="http://www.w3.org/2005/XQueryX" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2005/XQueryX http://www.w3.org/2005/XQueryX/xqueryx.xsd">
+    <xqx:mainModule>
+      <xqx:queryBody>
+        <xqx:integerConstantExpr>
+          <xqx:value>42</xqx:value>
+        </xqx:integerConstantExpr>
+      </xqx:queryBody>
+    </xqx:mainModule>
+</xqx:module>, map{})`,
+					documentNode,
+					domFacade,
+					null,
+					{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
+				),
+				42
+			));
+
+		it('throws when passed nonsense as an XQueryX program', () =>
+			chai.assert.throws(
+				() =>
+					evaluateXPathToNumber(
+						`fontoxpath:evaluate(<nonsense />, map{})`,
+						documentNode,
+						domFacade,
+						null,
+						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
+					),
+				'XPTY0004'
+			));
+
+		it('throws when passed invalid arguments', () => {
+			chai.assert.throws(
+				() =>
+					evaluateXPathToNumber(
+						`fontoxpath:evaluate(42, map{})`,
+						documentNode,
+						domFacade,
+						null,
+						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
+					),
+				'XPTY0004',
+				'When passed an integer'
+			);
+
+			chai.assert.throws(
+				() =>
+					evaluateXPathToNumber(
+						`fontoxpath:evaluate(map{}, map{})`,
+						documentNode,
+						domFacade,
+						null,
+						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
+					),
+				'XPTY0004',
+				'When passed a map'
+			);
+
+			chai.assert.throws(
+				() =>
+					evaluateXPathToNumber(
+						`fontoxpath:evaluate(true(), map{})`,
+						documentNode,
+						domFacade,
+						null,
+						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
+					),
+				'XPTY0004',
+				'When passed a boolean'
+			);
+		});
+
 		it('throws for an invalid expression during static evaluation and preserves debug details', () => {
 			// Execute a query which executes our registered custom xpath function
 			// Test if the error contains the actual failing XPath query

--- a/test/specs/parsing/functions/functions.fontoxpath.tests.ts
+++ b/test/specs/parsing/functions/functions.fontoxpath.tests.ts
@@ -181,7 +181,7 @@ describe('extension functions', () => {
 						null,
 						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
 					),
-				'XPTY0004',
+				/XPTY0004/,
 				'When passed an integer'
 			);
 
@@ -194,7 +194,7 @@ describe('extension functions', () => {
 						null,
 						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
 					),
-				'XPTY0004',
+				/XPTY0004/,
 				'When passed a map'
 			);
 
@@ -207,7 +207,7 @@ describe('extension functions', () => {
 						null,
 						{ language: evaluateXPath.XQUERY_3_1_LANGUAGE }
 					),
-				'XPTY0004',
+				/XPTY0004/,
 				'When passed a boolean'
 			);
 		});


### PR DESCRIPTION
This is required for a special case in Fonto: we sometimes retrieve a query from some registry before passing it to `fontoxpath:evaluate`. Now that we are working more and more with preparsed queries, `fontoxpath:evaluate` needs to be able to handle them.