### PR TITLE
Output the intersecting bucket for slightly more complex selectors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,8 @@ jobs:
     test:
         name: Tests on node.js ${{ matrix.node-version }}
         runs-on: ubuntu-latest
+        env:
+          NODE_OPTIONS: '--max_old_space_size=4096'
         strategy:
             fail-fast: false
             matrix:

--- a/src/domFacade/DomFacade.ts
+++ b/src/domFacade/DomFacade.ts
@@ -15,6 +15,7 @@ import {
 	TinyNode,
 	TinyParentNode,
 } from '../domClone/Pointer';
+import { Bucket } from '../expressions/util/Bucket';
 import {
 	ConcreteAttributeNode,
 	ConcreteCharacterDataNode,
@@ -63,7 +64,7 @@ class DomFacade {
 
 	public getAllAttributePointers(
 		pointer: ElementNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): AttributeNodePointer[] {
 		return this.getAllAttributes(pointer.node, bucket).map(
 			(attributeNode: ConcreteAttributeNode | TinyAttributeNode) =>
@@ -73,7 +74,7 @@ class DomFacade {
 
 	public getAllAttributes(
 		node: ConcreteElementNode | TinyElementNode,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): (ConcreteAttributeNode | TinyAttributeNode)[] {
 		return isTinyNode(node)
 			? node.attributes
@@ -95,7 +96,7 @@ class DomFacade {
 
 	public getChildNodePointers(
 		parentPointer: ParentNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ChildNodePointer[] {
 		return this.getChildNodes(parentPointer.node, bucket).map(
 			(childNode: ConcreteChildNode | TinyChildNode, index) =>
@@ -105,7 +106,7 @@ class DomFacade {
 
 	public getChildNodes(
 		parentNode: ConcreteParentNode | TinyParentNode,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	) {
 		const childNodes = isTinyNode(parentNode)
 			? parentNode.childNodes
@@ -144,7 +145,7 @@ class DomFacade {
 
 	public getFirstChildPointer(
 		parentPointer: ParentNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ChildNodePointer {
 		const parentNode = parentPointer.node;
 		let firstChild: ConcreteChildNode | TinyChildNode;
@@ -164,7 +165,7 @@ class DomFacade {
 
 	public getLastChildPointer(
 		parentPointer: ParentNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ChildNodePointer {
 		const parentNode = parentPointer.node;
 		let lastChild: ConcreteChildNode | TinyChildNode;
@@ -194,7 +195,7 @@ class DomFacade {
 
 	public getNextSiblingPointer(
 		pointer: ChildNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ChildNodePointer {
 		const node = pointer.node;
 		let nextSibling;
@@ -260,14 +261,14 @@ class DomFacade {
 	 */
 	public getParentNode(
 		node: ConcreteChildNode | ConcreteAttributeNode,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ConcreteParentNode {
 		return this._domFacade['getParentNode'](node, bucket) as ConcreteParentNode;
 	}
 
 	public getParentNodePointer(
 		pointer: ChildNodePointer | AttributeNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ParentNodePointer {
 		const childNode = pointer.node;
 		const graftAncestor = pointer.graftAncestor;
@@ -308,7 +309,7 @@ class DomFacade {
 
 	public getPreviousSiblingPointer(
 		pointer: ChildNodePointer,
-		bucket: string | null = null
+		bucket: Bucket | null = null
 	): ChildNodePointer {
 		const node = pointer.node;
 		let previousSibling;

--- a/src/domFacade/ExternalDomFacade.ts
+++ b/src/domFacade/ExternalDomFacade.ts
@@ -1,10 +1,11 @@
+import { Bucket } from '../expressions/util/Bucket';
 import { getBucketsForNode } from '../getBuckets';
 import { Attr, CharacterData, Node } from '../types/Types';
 import { NODE_TYPES } from './ConcreteNode';
 import IDomFacade from './IDomFacade';
 
 export default class ExternalDomFacade implements IDomFacade {
-	public ['getAllAttributes'](node: Node, bucket: string | null = null): Attr[] {
+	public ['getAllAttributes'](node: Node, bucket: Bucket | null = null): Attr[] {
 		if (node.nodeType !== NODE_TYPES.ELEMENT_NODE) {
 			return [];
 		}
@@ -20,7 +21,7 @@ export default class ExternalDomFacade implements IDomFacade {
 		}
 		return (node as any)['getAttribute'](attributeName);
 	}
-	public ['getChildNodes'](node: Node, bucket: string | null = null): Node[] {
+	public ['getChildNodes'](node: Node, bucket: Bucket | null = null): Node[] {
 		const childNodes = Array.from((node as any)['childNodes'] as Node[]);
 
 		if (bucket === null) {
@@ -34,7 +35,7 @@ export default class ExternalDomFacade implements IDomFacade {
 			? (node as any)['value']
 			: (node as any)['data'];
 	}
-	public ['getFirstChild'](node: Node, bucket: string | null = null): Node | null {
+	public ['getFirstChild'](node: Node, bucket: Bucket | null = null): Node | null {
 		for (
 			let child = (node as any)['firstChild'] as Node;
 			child;
@@ -47,7 +48,7 @@ export default class ExternalDomFacade implements IDomFacade {
 
 		return null;
 	}
-	public ['getLastChild'](node: Node, bucket: string | null = null): Node | null {
+	public ['getLastChild'](node: Node, bucket: Bucket | null = null): Node | null {
 		for (
 			let child = (node as any)['lastChild'] as Node;
 			child;
@@ -60,7 +61,7 @@ export default class ExternalDomFacade implements IDomFacade {
 
 		return null;
 	}
-	public ['getNextSibling'](node: Node, bucket: string | null = null): Node | null {
+	public ['getNextSibling'](node: Node, bucket: Bucket | null = null): Node | null {
 		for (
 			let sibling = (node as any)['nextSibling'] as Node;
 			sibling;
@@ -73,7 +74,7 @@ export default class ExternalDomFacade implements IDomFacade {
 
 		return null;
 	}
-	public ['getParentNode'](node: Node, bucket: string | null = null): Node | null {
+	public ['getParentNode'](node: Node, bucket: Bucket | null = null): Node | null {
 		const parentNode =
 			(node as any)['nodeType'] === NODE_TYPES.ATTRIBUTE_NODE
 				? (node as any)['ownerElement']
@@ -88,7 +89,7 @@ export default class ExternalDomFacade implements IDomFacade {
 		}
 		return null;
 	}
-	public ['getPreviousSibling'](node: Node, bucket: string | null = null): Node | null {
+	public ['getPreviousSibling'](node: Node, bucket: Bucket | null = null): Node | null {
 		for (
 			let sibling = (node as any)['previousSibling'] as Node;
 			sibling;

--- a/src/domFacade/IDomFacade.ts
+++ b/src/domFacade/IDomFacade.ts
@@ -1,3 +1,4 @@
+import { Bucket } from '../expressions/util/Bucket';
 import { Attr, CharacterData, Element, Node } from '../types/Types';
 
 /**
@@ -13,7 +14,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getAllAttributes(node: Element, bucket?: string | null): Attr[];
+	getAllAttributes(node: Element, bucket?: Bucket | null): Attr[];
 
 	/**
 	 * Get the value of specified attribute of this element.
@@ -30,7 +31,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getChildNodes(node: Node, bucket?: string | null): Node[];
+	getChildNodes(node: Node, bucket?: Bucket | null): Node[];
 
 	/**
 	 * Get the data of this element.
@@ -46,7 +47,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getFirstChild(node: Node, bucket?: string | null): Node | null;
+	getFirstChild(node: Node, bucket?: Bucket | null): Node | null;
 
 	/**
 	 * Get the last child of this element.
@@ -55,7 +56,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getLastChild(node: Node, bucket?: string | null): Node | null;
+	getLastChild(node: Node, bucket?: Bucket | null): Node | null;
 
 	/**
 	 * Get the next sibling of this node
@@ -64,7 +65,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the nextSibling that is requested.
 	 */
-	getNextSibling(node: Node, bucket?: string | null): Node | null;
+	getNextSibling(node: Node, bucket?: Bucket | null): Node | null;
 
 	/**
 	 * Get the parent of this element.
@@ -73,7 +74,7 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getParentNode(node: Node, bucket?: string | null): Node | null;
+	getParentNode(node: Node, bucket?: Bucket | null): Node | null;
 
 	/**
 	 * Get the previous sibling of this element.
@@ -82,5 +83,5 @@ export default interface IDomFacade {
 	 * @param  node -
 	 * @param  bucket - The bucket that matches the attribute that will be used.
 	 */
-	getPreviousSibling(node: Node, bucket?: string | null): Node | null;
+	getPreviousSibling(node: Node, bucket?: Bucket | null): Node | null;
 }

--- a/src/expressions/Expression.ts
+++ b/src/expressions/Expression.ts
@@ -4,6 +4,7 @@ import DynamicContext from './DynamicContext';
 import ExecutionParameters from './ExecutionParameters';
 import Specificity from './Specificity';
 import StaticContext from './StaticContext';
+import { Bucket } from './util/Bucket';
 import createDoublyIterableSequence from './util/createDoublyIterableSequence';
 import { errXUST0001 } from './xquery-update/XQueryUpdateFacilityErrors';
 
@@ -88,7 +89,7 @@ abstract class Expression {
 	 * applicable to a given node. Use getBucketsForNode to determine the buckets to consider for a
 	 * given node.
 	 */
-	public getBucket(): string | null {
+	public getBucket(): Bucket | null {
 		return null;
 	}
 

--- a/src/expressions/axes/AncestorAxis.ts
+++ b/src/expressions/axes/AncestorAxis.ts
@@ -7,13 +7,14 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket } from '../util/Bucket';
 import { DONE_TOKEN, ready } from '../util/iterators';
 import validateContextNode from './validateContextNode';
 
 function generateAncestors(
 	domFacade: DomFacade,
 	contextPointer: ChildNodePointer,
-	bucket: string | null
+	bucket: Bucket | null
 ) {
 	let ancestor = contextPointer as ParentNodePointer;
 	return {

--- a/src/expressions/axes/DescendantAxis.ts
+++ b/src/expressions/axes/DescendantAxis.ts
@@ -8,6 +8,7 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket } from '../util/Bucket';
 import createChildGenerator from '../util/createChildGenerator';
 import createSingleValueIterator from '../util/createSingleValueIterator';
 import { DONE_TOKEN, IIterator, IterationHint, ready } from '../util/iterators';
@@ -16,7 +17,7 @@ import validateContextNode from './validateContextNode';
 function createInclusiveDescendantGenerator(
 	domFacade: DomFacade,
 	node: ChildNodePointer,
-	bucket: string | null
+	bucket: Bucket | null
 ): IIterator<Value> {
 	const descendantIteratorStack: IIterator<ChildNodePointer>[] = [
 		createSingleValueIterator(node),
@@ -50,7 +51,7 @@ function createInclusiveDescendantGenerator(
 }
 
 class DescendantAxis extends Expression {
-	private _descendantBucket: string;
+	private _descendantBucket: Bucket;
 	private _descendantExpression: TestAbstractExpression;
 	private _isInclusive: boolean;
 

--- a/src/expressions/axes/FollowingAxis.ts
+++ b/src/expressions/axes/FollowingAxis.ts
@@ -9,6 +9,7 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket } from '../util/Bucket';
 import createDescendantGenerator from '../util/createDescendantGenerator';
 import { DONE_TOKEN, IIterator, IterationHint, ready } from '../util/iterators';
 import validateContextNode from './validateContextNode';
@@ -16,7 +17,7 @@ import validateContextNode from './validateContextNode';
 function createFollowingGenerator(
 	domFacade: DomFacade,
 	node: ChildNodePointer,
-	bucket: string | null
+	bucket: Bucket | null
 ) {
 	const nodeStack: NodePointer[] = [];
 
@@ -81,7 +82,7 @@ function createFollowingGenerator(
 }
 
 class FollowingAxis extends Expression {
-	private _bucket: string;
+	private _bucket: Bucket;
 	private _testExpression: TestAbstractExpression;
 
 	constructor(testExpression: TestAbstractExpression) {

--- a/src/expressions/axes/FollowingSiblingAxis.ts
+++ b/src/expressions/axes/FollowingSiblingAxis.ts
@@ -7,10 +7,11 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket, intersectBuckets } from '../util/Bucket';
 import { DONE_TOKEN, ready } from '../util/iterators';
 import validateContextNode from './validateContextNode';
 
-function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket: string | null) {
+function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket: Bucket | null) {
 	return {
 		next: () => {
 			node = node && domFacade.getNextSiblingPointer(node as ChildNodePointer, bucket);
@@ -24,8 +25,9 @@ function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket:
 }
 
 class FollowingSiblingAxis extends Expression {
-	private _siblingExpression: TestAbstractExpression;
-	constructor(siblingExpression: TestAbstractExpression) {
+	private readonly _filterBucket: Bucket;
+	private readonly _siblingExpression: TestAbstractExpression;
+	constructor(siblingExpression: TestAbstractExpression, filterBucket: Bucket) {
 		super(siblingExpression.specificity, [siblingExpression], {
 			resultOrder: RESULT_ORDERINGS.SORTED,
 			peer: true,
@@ -34,6 +36,7 @@ class FollowingSiblingAxis extends Expression {
 		});
 
 		this._siblingExpression = siblingExpression;
+		this._filterBucket = intersectBuckets(this._siblingExpression.getBucket(), filterBucket);
 	}
 
 	public evaluate(
@@ -44,13 +47,7 @@ class FollowingSiblingAxis extends Expression {
 		const contextPointer = validateContextNode(dynamicContext.contextItem);
 
 		return sequenceFactory
-			.create(
-				createSiblingGenerator(
-					domFacade,
-					contextPointer,
-					this._siblingExpression.getBucket()
-				)
-			)
+			.create(createSiblingGenerator(domFacade, contextPointer, this._filterBucket))
 			.filter((item) => {
 				return this._siblingExpression.evaluateToBoolean(
 					dynamicContext,

--- a/src/expressions/axes/ParentAxis.ts
+++ b/src/expressions/axes/ParentAxis.ts
@@ -6,11 +6,13 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket, intersectBuckets } from '../util/Bucket';
 import validateContextNode from './validateContextNode';
 
 class ParentAxis extends Expression {
-	private _parentExpression: TestAbstractExpression;
-	constructor(parentExpression: TestAbstractExpression) {
+	private readonly _filterBucket: Bucket;
+	private readonly _parentExpression: TestAbstractExpression;
+	constructor(parentExpression: TestAbstractExpression, filterBucket: Bucket) {
 		super(parentExpression.specificity, [parentExpression], {
 			resultOrder: RESULT_ORDERINGS.REVERSE_SORTED,
 			peer: true,
@@ -19,6 +21,7 @@ class ParentAxis extends Expression {
 		});
 
 		this._parentExpression = parentExpression;
+		this._filterBucket = intersectBuckets(filterBucket, this._parentExpression.getBucket());
 	}
 
 	public evaluate(
@@ -30,7 +33,7 @@ class ParentAxis extends Expression {
 
 		const parentNode = domFacade.getParentNodePointer(
 			contextPointer as ChildNodePointer,
-			this._parentExpression.getBucket()
+			this._filterBucket
 		);
 		if (!parentNode) {
 			return sequenceFactory.empty();

--- a/src/expressions/axes/PrecedingAxis.ts
+++ b/src/expressions/axes/PrecedingAxis.ts
@@ -9,6 +9,7 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket } from '../util/Bucket';
 import createDescendantGenerator from '../util/createDescendantGenerator';
 import { DONE_TOKEN, IIterator, IterationHint, ready } from '../util/iterators';
 import validateContextNode from './validateContextNode';
@@ -16,7 +17,7 @@ import validateContextNode from './validateContextNode';
 function createPrecedingGenerator(
 	domFacade: DomFacade,
 	node: ChildNodePointer,
-	bucket: string | null
+	bucket: Bucket | null
 ) {
 	const nodeStack: NodePointer[] = [];
 
@@ -78,7 +79,7 @@ function createPrecedingGenerator(
 }
 
 class PrecedingAxis extends Expression {
-	private _bucket: string;
+	private _bucket: Bucket;
 	private _testExpression: TestAbstractExpression;
 
 	constructor(testExpression: TestAbstractExpression) {

--- a/src/expressions/axes/PrecedingSiblingAxis.ts
+++ b/src/expressions/axes/PrecedingSiblingAxis.ts
@@ -7,10 +7,11 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket, intersectBuckets } from '../util/Bucket';
 import { DONE_TOKEN, ready } from '../util/iterators';
 import validateContextNode from './validateContextNode';
 
-function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket: string | null) {
+function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket: Bucket | null) {
 	return {
 		next: () => {
 			node = node && domFacade.getPreviousSiblingPointer(node as ChildNodePointer, bucket);
@@ -24,8 +25,10 @@ function createSiblingGenerator(domFacade: DomFacade, node: NodePointer, bucket:
 }
 
 class PrecedingSiblingAxis extends Expression {
-	private _siblingExpression: TestAbstractExpression;
-	constructor(siblingExpression: TestAbstractExpression) {
+	private readonly _filterBucket: Bucket;
+	private readonly _siblingExpression: TestAbstractExpression;
+
+	constructor(siblingExpression: TestAbstractExpression, filterBucket: Bucket) {
 		super(siblingExpression.specificity, [siblingExpression], {
 			canBeStaticallyEvaluated: false,
 			peer: true,
@@ -34,6 +37,7 @@ class PrecedingSiblingAxis extends Expression {
 		});
 
 		this._siblingExpression = siblingExpression;
+		this._filterBucket = intersectBuckets(this._siblingExpression.getBucket(), filterBucket);
 	}
 
 	public evaluate(
@@ -44,13 +48,7 @@ class PrecedingSiblingAxis extends Expression {
 		const contextPointer = validateContextNode(dynamicContext.contextItem);
 
 		return sequenceFactory
-			.create(
-				createSiblingGenerator(
-					domFacade,
-					contextPointer,
-					this._siblingExpression.getBucket()
-				)
-			)
+			.create(createSiblingGenerator(domFacade, contextPointer, this._filterBucket))
 			.filter((item) => {
 				return this._siblingExpression.evaluateToBoolean(
 					dynamicContext,

--- a/src/expressions/axes/SelfAxis.ts
+++ b/src/expressions/axes/SelfAxis.ts
@@ -4,11 +4,14 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import TestAbstractExpression from '../tests/TestAbstractExpression';
+import { Bucket, intersectBuckets } from '../util/Bucket';
 import validateContextNode from './validateContextNode';
 
 class SelfAxis extends Expression {
-	private _selector: TestAbstractExpression;
-	constructor(selector: TestAbstractExpression) {
+	private readonly _bucket: Bucket;
+	private readonly _selector: TestAbstractExpression;
+
+	constructor(selector: TestAbstractExpression, filterBucket: Bucket) {
 		super(selector.specificity, [selector], {
 			resultOrder: RESULT_ORDERINGS.SORTED,
 			subtree: true,
@@ -17,6 +20,7 @@ class SelfAxis extends Expression {
 		});
 
 		this._selector = selector;
+		this._bucket = intersectBuckets(this._selector.getBucket(), filterBucket);
 	}
 
 	public evaluate(
@@ -35,8 +39,8 @@ class SelfAxis extends Expression {
 			: sequenceFactory.empty();
 	}
 
-	public getBucket() {
-		return this._selector.getBucket();
+	public override getBucket(): Bucket {
+		return this._bucket;
 	}
 }
 export default SelfAxis;

--- a/src/expressions/operators/boolean/AndOperator.ts
+++ b/src/expressions/operators/boolean/AndOperator.ts
@@ -9,50 +9,11 @@ import DynamicContext from '../../DynamicContext';
 import ExecutionParameters from '../../ExecutionParameters';
 import Expression from '../../Expression';
 import Specificity from '../../Specificity';
+import { Bucket, intersectBuckets } from '../../util/Bucket';
 import { DONE_TOKEN, ready } from '../../util/iterators';
 
-// Some buckets include others. For the purpose of determining their intersection, this lists
-// "subtypes" per bucket, with all name-* buckets collapsed into "name".
-// Note that although "name" is not a strict subtype of either "type-1" or "type-2", it is generally
-// more specific than the type-based ones, so we consider it a subtype of both.
-const subBucketsByBucket: Record<string, string[]> = {
-	'type-1-or-type-2': ['name', 'type-1', 'type-2'],
-	'type-1': ['name'],
-	'type-2': ['name'],
-};
-
-function intersectBuckets(bucket1: string | null, bucket2: string | null): string | null {
-	// null bucket applies to everything
-	if (bucket1 === null) {
-		return bucket2;
-	}
-	if (bucket2 === null) {
-		return bucket1;
-	}
-	// Same bucket is same
-	if (bucket1 === bucket2) {
-		return bucket1;
-	}
-	// Find the more specific one, given that the buckets are not equal
-	const type1 = bucket1.startsWith('name-') ? 'name' : bucket1;
-	const type2 = bucket2.startsWith('name-') ? 'name' : bucket2;
-	const subtypes1 = subBucketsByBucket[type1];
-	if (subtypes1 !== undefined && subtypes1.includes(type2)) {
-		// bucket 2 is more specific
-		return bucket2;
-	}
-	const subtypes2 = subBucketsByBucket[type2];
-	if (subtypes2 !== undefined && subtypes2.includes(type1)) {
-		// bucket 1 is more specific
-		return bucket1;
-	}
-
-	// Expression will never match any nodes
-	return 'empty';
-}
-
 class AndOperator extends Expression {
-	private readonly _bucket: string | null;
+	private readonly _bucket: Bucket | null;
 	private readonly _subExpressions: Expression[];
 	constructor(expressions: Expression[], type: SequenceType) {
 		super(
@@ -69,7 +30,7 @@ class AndOperator extends Expression {
 			type
 		);
 		this._subExpressions = expressions;
-		this._bucket = expressions.reduce<string | null>(
+		this._bucket = expressions.reduce<Bucket | null>(
 			(bucket, expression) => intersectBuckets(bucket, expression.getBucket()),
 			null
 		);
@@ -128,7 +89,7 @@ class AndOperator extends Expression {
 		});
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket {
 		return this._bucket;
 	}
 }

--- a/src/expressions/operators/boolean/OrOperator.ts
+++ b/src/expressions/operators/boolean/OrOperator.ts
@@ -8,10 +8,11 @@ import DynamicContext from '../../DynamicContext';
 import ExecutionParameters from '../../ExecutionParameters';
 import Expression from '../../Expression';
 import Specificity from '../../Specificity';
+import { Bucket } from '../../util/Bucket';
 import { DONE_TOKEN, ready } from '../../util/iterators';
 
 class OrOperator extends Expression {
-	private _bucket: string;
+	private _bucket: Bucket | null;
 	private _subExpressions: Expression[];
 
 	constructor(expressions: Expression[], type: SequenceType) {
@@ -35,7 +36,7 @@ class OrOperator extends Expression {
 		);
 
 		// If all subExpressions define the same bucket: use that one, else, use no bucket.
-		let bucket: string;
+		let bucket: Bucket | null;
 		for (let i = 0; i < expressions.length; ++i) {
 			if (bucket === undefined) {
 				bucket = expressions[i].getBucket();
@@ -106,7 +107,7 @@ class OrOperator extends Expression {
 		});
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket | null {
 		return this._bucket;
 	}
 }

--- a/src/expressions/path/PathExpression.ts
+++ b/src/expressions/path/PathExpression.ts
@@ -8,6 +8,7 @@ import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import Specificity from '../Specificity';
+import { Bucket } from '../util/Bucket';
 import createSingleValueIterator from '../util/createSingleValueIterator';
 import { DONE_TOKEN, IIterator, IterationHint, ready } from '../util/iterators';
 import { concatSortedSequences, mergeSortedSequences } from '../util/sortedSequenceUtils';
@@ -165,7 +166,7 @@ class PathExpression extends Expression {
 		return result;
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket | null {
 		return this._stepExpressions[0].getBucket();
 	}
 }

--- a/src/expressions/postfix/Filter.ts
+++ b/src/expressions/postfix/Filter.ts
@@ -5,6 +5,7 @@ import Value, { ValueType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression from '../Expression';
+import { Bucket } from '../util/Bucket';
 import { DONE_TOKEN, IterationHint, IterationResult, ready } from '../util/iterators';
 
 class Filter extends Expression {
@@ -137,7 +138,7 @@ class Filter extends Expression {
 		});
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket | null {
 		return this._selector.getBucket();
 	}
 }

--- a/src/expressions/postfix/Lookup.ts
+++ b/src/expressions/postfix/Lookup.ts
@@ -2,6 +2,7 @@ import EmptySequence from '../dataTypes/Sequences/EmptySequence';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression from '../Expression';
+import { Bucket } from '../util/Bucket';
 import evaluateLookup from './evaluateLookup';
 
 class Lookup extends Expression {
@@ -36,7 +37,8 @@ class Lookup extends Expression {
 			}, new EmptySequence());
 		});
 	}
-	public getBucket() {
+
+	public override getBucket(): Bucket | null {
 		return this._selector.getBucket();
 	}
 }

--- a/src/expressions/tests/KindTest.ts
+++ b/src/expressions/tests/KindTest.ts
@@ -1,13 +1,16 @@
+import { NODE_TYPES } from '../../domFacade/ConcreteNode';
 import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import Value, { ValueType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
+import {} from '../Expression';
 import Specificity from '../Specificity';
+import { Bucket } from '../util/Bucket';
 import TestAbstractExpression from './TestAbstractExpression';
 
 class KindTest extends TestAbstractExpression {
-	private _nodeType: number;
-	constructor(nodeType: number) {
+	private _nodeType: NODE_TYPES;
+	constructor(nodeType: NODE_TYPES) {
 		super(
 			new Specificity({
 				[Specificity.NODETYPE_KIND]: 1,
@@ -32,9 +35,8 @@ class KindTest extends TestAbstractExpression {
 		}
 		return this._nodeType === nodeType;
 	}
-
-	public getBucket() {
-		return 'type-' + this._nodeType;
+	public override getBucket(): Bucket {
+		return `type-${this._nodeType}`;
 	}
 }
 export default KindTest;

--- a/src/expressions/tests/NameTest.ts
+++ b/src/expressions/tests/NameTest.ts
@@ -3,8 +3,10 @@ import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import Value, { ValueType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
+import {} from '../Expression';
 import Specificity from '../Specificity';
 import StaticContext from '../StaticContext';
+import { Bucket } from '../util/Bucket';
 import TestAbstractExpression from './TestAbstractExpression';
 
 class NameTest extends TestAbstractExpression {
@@ -82,14 +84,14 @@ class NameTest extends TestAbstractExpression {
 		return (domFacade.getNamespaceURI(node) || null) === (resolvedNamespaceURI || null);
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket {
 		if (this._localName === '*') {
 			if (this._kind === null) {
 				return 'type-1-or-type-2';
 			}
-			return `type-${this._kind}`;
+			return `type-${this._kind}` as Bucket;
 		}
-		return 'name-' + this._localName;
+		return `name-${this._localName}`;
 	}
 
 	public performStaticEvaluation(staticContext: StaticContext) {

--- a/src/expressions/tests/PITest.ts
+++ b/src/expressions/tests/PITest.ts
@@ -2,7 +2,9 @@ import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import Value, { ValueType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
+import {} from '../Expression';
 import Specificity from '../Specificity';
+import { Bucket } from '../util/Bucket';
 import TestAbstractExpression from './TestAbstractExpression';
 
 class PITest extends TestAbstractExpression {
@@ -30,7 +32,7 @@ class PITest extends TestAbstractExpression {
 		return isMatchingProcessingInstruction;
 	}
 
-	public getBucket() {
+	public override getBucket(): Bucket {
 		return 'type-7';
 	}
 }

--- a/src/expressions/util/Bucket.ts
+++ b/src/expressions/util/Bucket.ts
@@ -1,0 +1,80 @@
+/**
+ * Buckets are an optimization to XPaths. They are passed whenever FontoXPath can determine that only
+ * certain types of nodes will be used.
+ *
+ * For example, when evaluating the `child::element()` XPath, the `domFacade#getChildNodes` method will
+ * be called with a `type-1` bucket. Signaling text nodes or comments do not have to be returned.
+ *
+ * @see getBucketsForNode
+ * @see getBucketForSelector
+ *
+ * @public
+ */
+export type Bucket =
+	| 'type-1'
+	| 'type-2'
+	| 'type-3'
+	| 'type-4'
+	| 'type-7'
+	| 'type-8'
+	| 'type-9'
+	| 'type-10'
+	| 'type-11'
+	| `name-${string}`
+	| 'name'
+	| 'type-1-or-type-2'
+	| 'empty';
+
+// Some buckets include others. For the purpose of determining their intersection, this lists
+// "subtypes" per bucket, with all name-* buckets collapsed into "name".
+// Note that although "name" is not a strict subtype of either "type-1" or "type-2", it is generally
+// more specific than the type-based ones, so we consider it a subtype of both.
+const subBucketsByBucket: Map<Bucket, Bucket[]> = new Map([
+	['type-1-or-type-2', ['name', 'type-1', 'type-2']],
+	['type-1', ['name']],
+	['type-2', ['name']],
+]);
+
+/**
+ * Determine the intersection between the two passed buckets. The intersection is the 'strongest'
+ * bucket of the two. This may return `empty` if there is no such intersection.
+ *
+ * Example: `type-1` ∩ `null` = `type-1`
+ * Example: `type-1` ∩ `type-1-or-type-2` = `type-1`
+ * Example: `type-1` ∩ `name-p` = `name-p`
+ * Example: `name-p` ∩ `name-div` = `empty`
+ *
+ * @param  bucket1 - The first bucket to check
+ * @param  bucket2 - The second bucket to check
+ *
+ * @returns The intersection between the two buckets.
+ */
+export function intersectBuckets(bucket1: Bucket | null, bucket2: Bucket | null): Bucket | null {
+	// null bucket applies to everything
+	if (bucket1 === null) {
+		return bucket2;
+	}
+	if (bucket2 === null) {
+		return bucket1;
+	}
+	// Same bucket is same
+	if (bucket1 === bucket2) {
+		return bucket1;
+	}
+	// Find the more specific one, given that the buckets are not equal
+	const type1 = bucket1.startsWith('name-') ? 'name' : bucket1;
+	const type2 = bucket2.startsWith('name-') ? 'name' : bucket2;
+	const subtypes1 = subBucketsByBucket.get(type1);
+	if (subtypes1 !== undefined && subtypes1.includes(type2)) {
+		// bucket 2 is more specific
+		return bucket2;
+	}
+	const subtypes2 = subBucketsByBucket.get(type2);
+	if (subtypes2 !== undefined && subtypes2.includes(type1)) {
+		// bucket 1 is more specific
+		return bucket1;
+	}
+
+	// Expression will never match any nodes
+	return 'empty';
+}

--- a/src/expressions/util/createChildGenerator.ts
+++ b/src/expressions/util/createChildGenerator.ts
@@ -1,12 +1,13 @@
 import { ChildNodePointer, NodePointer, ParentNodePointer } from '../../domClone/Pointer';
 import { NODE_TYPES } from '../../domFacade/ConcreteNode';
 import DomFacade from '../../domFacade/DomFacade';
+import { Bucket } from './Bucket';
 import { DONE_TOKEN, IIterator, ready } from './iterators';
 
 export default function createChildGenerator(
 	domFacade: DomFacade,
 	pointer: NodePointer,
-	bucket: string | null
+	bucket: Bucket | null
 ): IIterator<ChildNodePointer> {
 	const nodeType = domFacade.getNodeType(pointer);
 	if (nodeType !== NODE_TYPES.ELEMENT_NODE && nodeType !== NODE_TYPES.DOCUMENT_NODE) {

--- a/src/expressions/util/createDescendantGenerator.ts
+++ b/src/expressions/util/createDescendantGenerator.ts
@@ -3,13 +3,14 @@ import { NODE_TYPES } from '../../domFacade/ConcreteNode';
 import DomFacade from '../../domFacade/DomFacade';
 import createPointerValue from '../dataTypes/createPointerValue';
 import arePointersEqual from '../operators/compares/arePointersEqual';
+import { Bucket } from './Bucket';
 import createChildGenerator from './createChildGenerator';
 import { DONE_TOKEN, IterationHint, ready } from './iterators';
 
 function findDeepestLastDescendant(
 	pointer: NodePointer,
 	domFacade: DomFacade,
-	bucket: string | null
+	bucket: Bucket | null
 ): NodePointer {
 	const nodeType = domFacade.getNodeType(pointer);
 	if (nodeType !== NODE_TYPES.ELEMENT_NODE && nodeType !== NODE_TYPES.DOCUMENT_NODE) {
@@ -32,7 +33,7 @@ export default function createDescendantGenerator(
 	domFacade: DomFacade,
 	pointer: NodePointer,
 	returnInReverse = false,
-	bucket: string | null
+	bucket: Bucket | null
 ) {
 	if (returnInReverse) {
 		let currentPointer: NodePointer = pointer;

--- a/src/getBuckets.ts
+++ b/src/getBuckets.ts
@@ -1,25 +1,26 @@
 import { AttributeNodePointer, ElementNodePointer, NodePointer } from './domClone/Pointer';
 import { NODE_TYPES } from './domFacade/ConcreteNode';
 import DomFacade from './domFacade/DomFacade';
+import { Bucket } from './expressions/util/Bucket';
 import { Attr, Element, Node } from './types/Types';
 
-function createBuckets(nodeType: NODE_TYPES, localName?: string): string[] {
-	const buckets = [];
+function createBuckets(nodeType: NODE_TYPES, localName?: string): Bucket[] {
+	const buckets: Bucket[] = [];
 
 	if (nodeType === NODE_TYPES.ATTRIBUTE_NODE || nodeType === NODE_TYPES.ELEMENT_NODE) {
 		buckets.push('type-1-or-type-2');
 	}
 
-	buckets.push('type-' + nodeType);
+	buckets.push(`type-${nodeType}`);
 
 	if (localName) {
-		buckets.push('name-' + localName);
+		buckets.push(`name-${localName}`);
 	}
 
 	return buckets;
 }
 
-export function getBucketsForPointer(pointer: NodePointer, domFacade: DomFacade): string[] {
+export function getBucketsForPointer(pointer: NodePointer, domFacade: DomFacade): Bucket[] {
 	const nodeType = domFacade.getNodeType(pointer);
 	let localName;
 	if (nodeType === NODE_TYPES.ATTRIBUTE_NODE || nodeType === NODE_TYPES.ELEMENT_NODE) {
@@ -40,7 +41,7 @@ export function getBucketsForPointer(pointer: NodePointer, domFacade: DomFacade)
  *
  * @param node - The node which buckets should be retrieved
  */
-export function getBucketsForNode(node: Node): string[] {
+export function getBucketsForNode(node: Node): Bucket[] {
 	const nodeType = node.nodeType;
 	let localName;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import evaluateXPathToNumbers from './evaluateXPathToNumbers';
 import evaluateXPathToString from './evaluateXPathToString';
 import evaluateXPathToStrings from './evaluateXPathToStrings';
 import executePendingUpdateList from './executePendingUpdateList';
+import { Bucket } from './expressions/util/Bucket';
 import { getBucketsForNode } from './getBuckets';
 import compileXPathToJavaScript from './jsCodegen/compileXPathToJavaScript';
 import executeJavaScriptCompiledXPath, {
@@ -109,7 +110,7 @@ function parseXPath(xpathExpression: EvaluableExpression) {
  * @public
  * @param xpathExpression - The XPath for which a bucket should be retrieved
  */
-function getBucketForSelector(xpathExpression: EvaluableExpression) {
+function getBucketForSelector(xpathExpression: EvaluableExpression): Bucket {
 	return parseXPath(xpathExpression).getBucket();
 }
 
@@ -202,6 +203,7 @@ export const createTypedValueFactory = internalCreateTypedValueFactory as Extern
 
 export {
 	Attr,
+	Bucket,
 	CDATASection,
 	CharacterData,
 	Comment,

--- a/src/jsCodegen/CodeGenContext.ts
+++ b/src/jsCodegen/CodeGenContext.ts
@@ -1,3 +1,4 @@
+import { Bucket } from '../expressions/util/Bucket';
 import { IAST } from '../parsing/astHelper';
 import { NamespaceResolver } from '../types/Options';
 import { FunctionIdentifier, PartialCompilationResult } from './JavaScriptCompiledXPath';
@@ -7,6 +8,6 @@ export type CodeGenContext = {
 		ast: IAST,
 		identifier: FunctionIdentifier,
 		staticContext: CodeGenContext
-	) => PartialCompilationResult;
+	) => [PartialCompilationResult, Bucket];
 	resolveNamespace: NamespaceResolver;
 };

--- a/src/jsCodegen/compileAstToJavaScript.ts
+++ b/src/jsCodegen/compileAstToJavaScript.ts
@@ -165,7 +165,7 @@ function compileAstToJavaScript(
 
 	staticContext.emitBaseExpr = emitBaseExpr;
 
-	const compiledBaseExpr = emitBaseExpr(
+	const [compiledBaseExpr, _bucket] = emitBaseExpr(
 		queryBodyContents,
 		compiledXPathIdentifier,
 		staticContext

--- a/src/jsCodegen/emitBaseExpression.ts
+++ b/src/jsCodegen/emitBaseExpression.ts
@@ -1,18 +1,13 @@
+import { Bucket } from '../expressions/util/Bucket';
 import { IAST } from '../parsing/astHelper';
 import { CodeGenContext } from './CodeGenContext';
 import { emitCompareExpr } from './emitCompare';
 import { emitFunctionCallExpr } from './emitFunctionCallExpr';
 import { emitStringLiteralExpression } from './emitLiterals';
 import { emitAndExpr, emitOrExpr } from './emitLogicalExpr';
-import { baseExprAstNodes, baseExpressions } from './emitOperand';
+import { baseExprAstNodes } from './emitOperand';
 import { emitPathExpr } from './emitPathExpr';
-import {
-	acceptAst,
-	FunctionIdentifier,
-	GeneratedCodeBaseType,
-	PartialCompilationResult,
-	rejectAst,
-} from './JavaScriptCompiledXPath';
+import { FunctionIdentifier, PartialCompilationResult, rejectAst } from './JavaScriptCompiledXPath';
 
 /**
  * Compile AST to base expression wrapped in a function named as the given identifier.
@@ -27,7 +22,7 @@ export function emitBaseExpr(
 	ast: IAST,
 	identifier: FunctionIdentifier,
 	staticContext: CodeGenContext
-): PartialCompilationResult {
+): [PartialCompilationResult, Bucket] {
 	const name = ast[0];
 
 	switch (name) {
@@ -57,10 +52,10 @@ export function emitBaseExpr(
 		// nodeCompare
 		case baseExprAstNodes.NODE_BEFORE_OP:
 		case baseExprAstNodes.NODE_AFTER_OP:
-			return emitCompareExpr(ast, identifier, staticContext, name);
+			return [emitCompareExpr(ast, identifier, staticContext, name), null];
 		case baseExprAstNodes.FUNCTION_CALL_EXPR:
-			return emitFunctionCallExpr(ast, identifier, staticContext);
+			return [emitFunctionCallExpr(ast, identifier, staticContext), null];
 		default:
-			return rejectAst(`Unsupported: the base expression '${name}'.`);
+			return [rejectAst(`Unsupported: the base expression '${name}'.`), null];
 	}
 }

--- a/src/jsCodegen/emitCompare.ts
+++ b/src/jsCodegen/emitCompare.ts
@@ -7,7 +7,6 @@ import {
 import astHelper, { IAST } from '../parsing/astHelper';
 import { CodeGenContext } from './CodeGenContext';
 import { emitOperand } from './emitOperand';
-// import { emitBaseExpr } from './emitBaseExpression';
 import {
 	acceptAst,
 	FunctionIdentifier,
@@ -149,9 +148,7 @@ export function emitGeneralCompare(
 	identifier: string,
 	staticContext: CodeGenContext
 ): PartialCompilationResult {
-	const firstAstOp = astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST;
 	const firstType: SequenceType = astHelper.getAttribute(ast, 'type');
-	const secondAstOp = astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST;
 	const secondType: SequenceType = astHelper.getAttribute(ast, 'type');
 	if (!firstType || !secondType) {
 		return rejectAst('types of compare are not known');
@@ -189,12 +186,17 @@ export function emitCompareExpr(
 	staticContext: CodeGenContext,
 	compareType: string
 ): PartialCompilationResult {
-	const firstExpr = emitOperand(ast, identifier, 'firstOperand', staticContext);
+	const [firstExpr, _firstBucket] = emitOperand(ast, identifier, 'firstOperand', staticContext);
 	if (!firstExpr.isAstAccepted) {
 		return firstExpr;
 	}
 
-	const secondExpr = emitOperand(ast, identifier, 'secondOperand', staticContext);
+	const [secondExpr, _secondBucket] = emitOperand(
+		ast,
+		identifier,
+		'secondOperand',
+		staticContext
+	);
 	if (!secondExpr.isAstAccepted) {
 		return secondExpr;
 	}

--- a/src/jsCodegen/emitFunctionCallExpr.ts
+++ b/src/jsCodegen/emitFunctionCallExpr.ts
@@ -5,9 +5,7 @@ import {
 	FunctionIdentifier,
 	GeneratedCodeBaseType,
 	getCompiledValueCode,
-	IAstRejected,
 	PartialCompilationResult,
-	PartiallyCompiledAstAccepted,
 	rejectAst,
 } from './JavaScriptCompiledXPath';
 
@@ -28,7 +26,7 @@ function emitArgument(
 	staticContext: CodeGenContext,
 	identifier: FunctionIdentifier
 ): PartialCompilationResult {
-	const baseExpr = staticContext.emitBaseExpr(ast, identifier, staticContext);
+	const [baseExpr, _bucket] = staticContext.emitBaseExpr(ast, identifier, staticContext);
 
 	if (!baseExpr.isAstAccepted) {
 		return baseExpr;
@@ -60,7 +58,7 @@ function createLocalNameGetter(itemName: string) {
 }
 
 function createNameGetter(itemName: string) {
-	return `(((${itemName}.prefix || '').length !== 0 ? ${itemName}.prefix + ':' : '') 
+	return `(((${itemName}.prefix || '').length !== 0 ? ${itemName}.prefix + ':' : '')
 		+ (${itemName}.localName || ${itemName}.target || ''))`;
 }
 

--- a/src/jsCodegen/emitLiterals.ts
+++ b/src/jsCodegen/emitLiterals.ts
@@ -1,3 +1,4 @@
+import { Bucket } from '../expressions/util/Bucket';
 import astHelper, { IAST } from '../parsing/astHelper';
 import escapeJavaScriptString from './escapeJavaScriptString';
 import {
@@ -19,9 +20,12 @@ import {
 export function emitStringLiteralExpression(
 	ast: IAST,
 	identifier: FunctionIdentifier
-): PartialCompilationResult {
+): [PartialCompilationResult, Bucket] {
 	// Note: default the value to the emptyy string. The XQueryX roundtrip may omit them
 	let text = (astHelper.getFirstChild(ast, 'value')[1] as string) || '';
 	text = escapeJavaScriptString(text);
-	return acceptAst(`const ${identifier} = ${text};`, { type: GeneratedCodeBaseType.Variable });
+	return [
+		acceptAst(`const ${identifier} = ${text};`, { type: GeneratedCodeBaseType.Variable }),
+		null,
+	];
 }

--- a/src/jsCodegen/emitStep.ts
+++ b/src/jsCodegen/emitStep.ts
@@ -180,20 +180,20 @@ function emitStep(
 	nestLevel: number,
 	nestedCode: string,
 	bucket: Bucket | null
-): PartialCompilationResult {
+): [PartialCompilationResult, Bucket] {
 	const axisName = astHelper.getTextContent(ast);
 
 	switch (axisName) {
 		case axisAstNodes.ATTRIBUTE:
-			return emitAttributeAxis(test, predicates, nestLevel, nestedCode, bucket);
+			return [emitAttributeAxis(test, predicates, nestLevel, nestedCode, bucket), 'type-1'];
 		case axisAstNodes.CHILD:
-			return emitChildAxis(test, predicates, nestLevel, nestedCode, bucket);
+			return [emitChildAxis(test, predicates, nestLevel, nestedCode, bucket), null];
 		case axisAstNodes.PARENT:
-			return emitParentAxis(test, predicates, nestLevel, nestedCode, bucket);
+			return [emitParentAxis(test, predicates, nestLevel, nestedCode, bucket), null];
 		case axisAstNodes.SELF:
-			return emitSelfAxis(test, predicates, nestLevel, nestedCode);
+			return [emitSelfAxis(test, predicates, nestLevel, nestedCode), bucket];
 		default:
-			return rejectAst(`Unsupported: the ${axisName} axis`);
+			return [rejectAst(`Unsupported: the ${axisName} axis`), null];
 	}
 }
 

--- a/src/jsCodegen/emitStep.ts
+++ b/src/jsCodegen/emitStep.ts
@@ -1,4 +1,5 @@
 import { NODE_TYPES } from '../domFacade/ConcreteNode';
+import { Bucket } from '../expressions/util/Bucket';
 import astHelper, { IAST } from '../parsing/astHelper';
 import {
 	acceptAst,
@@ -26,7 +27,7 @@ function emitChildAxis(
 	predicates: string,
 	nestLevel: number,
 	nestedCode: string,
-	bucket: string | null
+	bucket: Bucket | null
 ): PartialCompilationResult {
 	const contextNodesCode = `const ${childAxisContextNodesIdentifier}${nestLevel} = domFacade.getChildNodes(contextItem${
 		nestLevel - 1
@@ -49,7 +50,7 @@ function emitAttributeAxis(
 	predicates: string,
 	nestLevel: number,
 	nestedCode: string,
-	bucket: string | null
+	bucket: Bucket | null
 ): PartialCompilationResult {
 	// Only element nodes can have attributes.
 	const contextNodesCode = `
@@ -94,7 +95,7 @@ function emitParentAxis(
 	predicates: string,
 	nestLevel: number,
 	nestedCode: string,
-	bucket: string | null
+	bucket: Bucket | null
 ): PartialCompilationResult {
 	const contextNodeCode = `
 	const contextItem${nestLevel} = domFacade.getParentNode(contextItem${nestLevel - 1} ${
@@ -178,7 +179,7 @@ function emitStep(
 	predicates: string,
 	nestLevel: number,
 	nestedCode: string,
-	bucket: string | null
+	bucket: Bucket | null
 ): PartialCompilationResult {
 	const axisName = astHelper.getTextContent(ast);
 

--- a/src/jsCodegen/emitTest.ts
+++ b/src/jsCodegen/emitTest.ts
@@ -1,11 +1,11 @@
 import { NODE_TYPES } from '../domFacade/ConcreteNode';
 import QName from '../expressions/dataTypes/valueTypes/QName';
+import { Bucket } from '../expressions/util/Bucket';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { CodeGenContext } from './CodeGenContext';
 import escapeJavaScriptString from './escapeJavaScriptString';
 import {
 	acceptAst,
-	CompiledResultType,
 	ContextItemIdentifier,
 	GeneratedCodeBaseType,
 	PartialCompilationResult,
@@ -26,7 +26,7 @@ export const tests = Object.values(testAstNodes);
 function emitTextTest(
 	_ast: IAST,
 	identifier: ContextItemIdentifier
-): [PartialCompilationResult, string | null] {
+): [PartialCompilationResult, Bucket | null] {
 	return [
 		acceptAst(`${identifier}.nodeType === /*TEXT_NODE*/ ${NODE_TYPES.TEXT_NODE}`, {
 			type: GeneratedCodeBaseType.Value,
@@ -49,7 +49,7 @@ function emitNameTestFromQName(
 	identifier: ContextItemIdentifier,
 	qName: QName,
 	staticContext: CodeGenContext
-): [PartialCompilationResult, string | null] {
+): [PartialCompilationResult, Bucket | null] {
 	const namespaceURIWasResolved = qName.namespaceURI === null;
 	resolveNamespaceURI(qName, staticContext);
 	const { prefix, namespaceURI, localName } = qName;
@@ -114,7 +114,7 @@ function emitElementTest(
 	ast: IAST,
 	identifier: ContextItemIdentifier,
 	staticContext: CodeGenContext
-): [PartialCompilationResult, string | null] {
+): [PartialCompilationResult, Bucket | null] {
 	const elementName = astHelper.getFirstChild(ast, 'elementName');
 	const star = elementName && astHelper.getFirstChild(elementName, 'star');
 	const isElementCode = `${identifier}.nodeType === /*ELEMENT_NODE*/ ${NODE_TYPES.ELEMENT_NODE}`;
@@ -141,7 +141,7 @@ function emitWildcard(
 	ast: IAST,
 	identifier: ContextItemIdentifier,
 	staticContext: CodeGenContext
-): [PartialCompilationResult, string | null] {
+): [PartialCompilationResult, Bucket | null] {
 	if (!astHelper.getFirstChild(ast, 'star')) {
 		return emitNameTestFromQName(
 			identifier,
@@ -198,7 +198,7 @@ export default function emitTest(
 	ast: IAST,
 	identifier: ContextItemIdentifier,
 	staticContext: CodeGenContext
-): [PartialCompilationResult, string | null] {
+): [PartialCompilationResult, Bucket | null] {
 	// emitTest returns a tuple of the generated code and an optional bucket.
 
 	const test = ast[0];

--- a/src/jsCodegen/runtimeLib.ts
+++ b/src/jsCodegen/runtimeLib.ts
@@ -1,12 +1,10 @@
 import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
 import getEffectiveBooleanValue from '../expressions/dataTypes/Sequences/getEffectiveBooleanValue';
-import Value from '../expressions/dataTypes/Value';
-import { DONE_TOKEN, IterationResult, ready } from '../expressions/util/iterators';
+import { DONE_TOKEN, ready } from '../expressions/util/iterators';
 import {
 	acceptAst,
 	GeneratedCodeBaseType,
 	GeneratedCodeType,
-	getCompiledValueCode,
 	PartialCompilationResult,
 } from './JavaScriptCompiledXPath';
 
@@ -36,7 +34,7 @@ export function determinePredicateTruthValue(
 			return acceptAst(
 				`(() => {
 					const result = ${identifier}.next();
-					return result.done ? false : !!result.value; 
+					return result.done ? false : !!result.value;
 				})()`,
 				{ type: GeneratedCodeBaseType.Value }
 			);

--- a/test/specs/expressions/postfix/Filter.tests.ts
+++ b/test/specs/expressions/postfix/Filter.tests.ts
@@ -17,10 +17,13 @@ describe('Filter', () => {
 	describe('Filter.getBucket()', () => {
 		it('returns the bucket of its selector', () => {
 			const filter = new Filter(
-				{ getBucket: () => 'bucket', specificity: new Specificity({}) } as Expression,
+				{
+					getBucket: () => 'name-just-for-testing',
+					specificity: new Specificity({}),
+				} as unknown as Expression,
 				equalExpression
 			);
-			chai.assert.equal(filter.getBucket(), 'bucket');
+			chai.assert.equal(filter.getBucket(), 'name-just-for-testing');
 		});
 	});
 

--- a/test/specs/parsing/axes/AttributeAxis.tests.ts
+++ b/test/specs/parsing/axes/AttributeAxis.tests.ts
@@ -170,4 +170,20 @@ describe('attribute', () => {
 
 		evaluateXPathToString('@xxx', element, testDomFacade);
 	});
+
+	it('passes the intersecting bucket', () => {
+		const element = documentNode.createElement('someElement');
+		const attr = element.setAttribute('xxx', 'yyy');
+		const expectedBucket = getBucketForSelector('self::xxx');
+
+		const testDomFacade: IDomFacade = {
+			getAllAttributes: (node, bucket: string | null) => {
+				chai.assert.equal(bucket, expectedBucket);
+				return node.attributes;
+			},
+			getData: (attribute: Attr) => attribute.value,
+		} as any;
+
+		evaluateXPathToString('@*[self::xxx]', element, testDomFacade);
+	});
 });

--- a/test/specs/parsing/axes/ChildAxis.tests.ts
+++ b/test/specs/parsing/axes/ChildAxis.tests.ts
@@ -75,6 +75,22 @@ describe('child', () => {
 		evaluateXPathToNodes('child::childElement', parent, testDomFacade);
 	});
 
+	it('passes the intersecting bucket for getChildNodes', () => {
+		jsonMlMapper.parse(['parentElement', ['childElement']], documentNode);
+
+		const parent = documentNode.firstChild;
+		const expectedBucket = getBucketForSelector('self::childElement');
+
+		const testDomFacade: IDomFacade = {
+			getChildNodes: (node, bucket: string | null) => {
+				chai.assert.equal(expectedBucket, bucket);
+				return [];
+			},
+		} as any;
+
+		evaluateXPathToNodes('child::*[self::childElement]', parent, testDomFacade);
+	});
+
 	it('throws the correct error if context is absent', () => {
 		chai.assert.throws(() => evaluateXPathToFirstNode('*', null), 'XPDY0002');
 	});

--- a/test/specs/parsing/axes/FollowingSiblingAxis.tests.ts
+++ b/test/specs/parsing/axes/FollowingSiblingAxis.tests.ts
@@ -69,6 +69,37 @@ describe('following-sibling', () => {
 		);
 	});
 
+	it('passes intersecting buckets for followingSibling', () => {
+		jsonMlMapper.parse(
+			['parentElement', ['firstChildElement'], ['secondChildElement']],
+			documentNode
+		);
+
+		const firstChildNode = documentNode.firstChild.firstChild;
+		const expectedBucket = getBucketForSelector('self::secondChildElement');
+
+		const testDomFacade: IDomFacade = {
+			getFirstChild: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(expectedBucket, bucket);
+				return node.firstChild;
+			},
+			getNextSibling: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(expectedBucket, bucket);
+				return node.nextSibling;
+			},
+			getParentNode: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(expectedBucket, bucket);
+				return node.parentNode;
+			},
+		} as any;
+
+		evaluateXPathToNodes(
+			'following-sibling::*[self::secondChildElement]',
+			firstChildNode,
+			testDomFacade
+		);
+	});
+
 	it('throws the correct error if context is absent', () => {
 		chai.assert.throws(() => evaluateXPathToNodes('following-sibling::*', null), 'XPDY0002');
 	});

--- a/test/specs/parsing/axes/ParentAxis.tests.ts
+++ b/test/specs/parsing/axes/ParentAxis.tests.ts
@@ -59,6 +59,22 @@ describe('parent', () => {
 		evaluateXPathToFirstNode('parent::parentElement', childNode, testDomFacade);
 	});
 
+	it('passes the intersecting buckets for getParentNode', () => {
+		jsonMlMapper.parse(['parentElement', ['childElement']], documentNode);
+
+		const childNode = documentNode.firstChild.firstChild;
+		const expectedBucket = getBucketForSelector('self::parentElement');
+
+		const testDomFacade: IDomFacade = {
+			getParentNode: (_node: Node, bucket: string | null) => {
+				chai.assert.equal(expectedBucket, bucket);
+				return null;
+			},
+		} as any;
+
+		evaluateXPathToFirstNode('parent::*[self::parentElement]', childNode, testDomFacade);
+	});
+
 	it('throws the correct error if context is absent', () => {
 		chai.assert.throws(() => evaluateXPathToNodes('parent::*', null), 'XPDY0002');
 	});

--- a/test/specs/parsing/axes/PrecedingSibling.tests.ts
+++ b/test/specs/parsing/axes/PrecedingSibling.tests.ts
@@ -69,6 +69,37 @@ describe('preceding-sibling', () => {
 		);
 	});
 
+	it('passes intersecting buckets for preceding-sibling', () => {
+		jsonMlMapper.parse(
+			['parentElement', ['firstChildElement'], ['secondChildElement']],
+			documentNode
+		);
+
+		const secondChildNode = documentNode.firstChild.lastChild;
+		const expectedBucket = getBucketForSelector('self::firstChildElement');
+
+		const testDomFacade: IDomFacade = {
+			getLastChild: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(bucket, expectedBucket);
+				return node.lastChild;
+			},
+			getParentNode: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(bucket, expectedBucket);
+				return node.parentNode;
+			},
+			getPreviousSibling: (node: slimdom.Node, bucket: string | null) => {
+				chai.assert.equal(bucket, expectedBucket);
+				return node.previousSibling;
+			},
+		} as any;
+
+		evaluateXPathToNodes(
+			'preceding-sibling::*[self::firstChildElement]',
+			secondChildNode,
+			testDomFacade
+		);
+	});
+
 	it('throws the correct error if context is absent', () => {
 		chai.assert.throws(() => evaluateXPathToNodes('preceding-sibling::*', null), 'XPDY0002');
 	});

--- a/test/specs/parsing/axes/SelfAxis.tests.ts
+++ b/test/specs/parsing/axes/SelfAxis.tests.ts
@@ -1,7 +1,7 @@
 import * as chai from 'chai';
 import * as slimdom from 'slimdom';
 
-import { evaluateXPathToFirstNode } from 'fontoxpath';
+import { evaluateXPathToFirstNode, getBucketForSelector, getBucketsForNode } from 'fontoxpath';
 
 let documentNode;
 beforeEach(() => {
@@ -11,8 +11,27 @@ beforeEach(() => {
 describe('self', () => {
 	it('parses self::', () => {
 		const element = documentNode.createElement('someElement');
-		chai.assert.deepEqual(evaluateXPathToFirstNode('self::someElement', element), element);
+		chai.assert.equal(evaluateXPathToFirstNode('self::someElement', element), element);
 	});
+
+	it('returns the correct bucket', () => {
+		const element = documentNode.createElement('someElement');
+		chai.assert.include(
+			getBucketsForNode(element),
+			getBucketForSelector('self::someElement'),
+			'The self::element selector should have the matching buckets'
+		);
+	});
+
+	it('returns the correct intersecting bucket', () => {
+		const element = documentNode.createElement('someElement');
+		chai.assert.include(
+			getBucketsForNode(element),
+			getBucketForSelector('self::*[self::someElement]'),
+			'The self::*[self::someElement] selector should have the matching buckets'
+		);
+	});
+
 	it('throws the correct error if context is absent', () => {
 		chai.assert.throws(() => evaluateXPathToFirstNode('self::*', null), 'XPDY0002');
 	});

--- a/test/specs/parsing/tests/NameTest.tests.ts
+++ b/test/specs/parsing/tests/NameTest.tests.ts
@@ -100,8 +100,8 @@ describe('nameTests', () => {
 		it('returns type-1-or-type-2 if the selector is "self::*"', () => {
 			chai.assert.equal(getBucketForSelector('self::*'), 'type-1-or-type-2');
 		});
-		it('returns type-1-or-2 if the selector is "self::*[@attr]"', () => {
-			chai.assert.equal(getBucketForSelector('self::*[@attr]'), 'type-1-or-type-2');
+		it('returns type-1 if the selector is "self::*[@attr]"', () => {
+			chai.assert.equal(getBucketForSelector('self::*[@attr]'), 'type-1');
 		});
 		it('returns type-1 if the selector is "self::element(*)"', () => {
 			chai.assert.equal(getBucketForSelector('self::element(*)'), 'type-1');


### PR DESCRIPTION
For a selector looking like `child::p`, we ask for children with a bucket `name-p`, but for
`child::*[name-p]` we previously did not. We now do exactly that: use the intersection between the
two buckets (`type-1` and `name-p`) and return the strongest one!