### PR TITLE
Allow parsing XQuery modules

### DIFF
--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -229,7 +229,17 @@ export default function parseScript<TElement extends Element>(
 		options['functionNameResolver'] || (() => null)
 	);
 	const rootStaticContext = new StaticContext(executionSpecificStaticContext);
-	const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);
+	const anyModuleDecl = astHelper.getFirstChild(ast, ['mainModule', 'libraryModule']);
+	// Spike the static context if we are actually a library module
+	const moduleDecl = astHelper.getFirstChild(anyModuleDecl, 'moduleDecl');
+	if (moduleDecl) {
+		const prefix = astHelper.getTextContent(astHelper.getFirstChild(moduleDecl, 'prefix'));
+		const uri = astHelper.getTextContent(astHelper.getFirstChild(moduleDecl, 'uri'));
+
+		rootStaticContext.registerNamespace(prefix, uri);
+	}
+
+	const prolog = astHelper.getFirstChild(anyModuleDecl, 'prolog');
 
 	if (prolog) {
 		processProlog(prolog, rootStaticContext, false);

--- a/test/specs/parsing/parseScript.tests.ts
+++ b/test/specs/parsing/parseScript.tests.ts
@@ -244,6 +244,22 @@ some-function#0()
 		chai.assert.equal(document.documentElement.outerHTML, '<baz><foo>bar</foo></baz>');
 	});
 
+	it('can parse an XQuery module', () => {
+		const document = new Document();
+		const ast = parseScript(
+			`module namespace prefix = "http://www.example.com/";
+
+declare %public function prefix:ok() as xs:string {
+	"ok"
+};
+`,
+			{},
+			document
+		);
+
+		chai.assert.isOk(ast);
+	});
+
 	it('can execute a map function within an AST', () => {
 		const ast = parseScript('map:put($week, "1", "Monday")', {}, new Document());
 		const result = evaluateXPathToMap(ast, null, null, {


### PR DESCRIPTION
There was a small bug: a nullref when you'd parse an XQuery module directly