### PR TITLE
Cache expressions in fontoxpath:evaluate

### DIFF
--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -189,6 +189,7 @@ export default function buildEvaluationContext(
 
 	const executionParameters = new ExecutionParameters(
 		compilationOptions.debug,
+		compilationOptions.disableCache,
 		wrappedDomFacade,
 		nodesFactory,
 		documentWriter,

--- a/src/expressions/ExecutionParameters.ts
+++ b/src/expressions/ExecutionParameters.ts
@@ -8,6 +8,7 @@ import { Logger } from '../types/Options';
 export default class ExecutionParameters {
 	constructor(
 		public readonly debug: boolean,
+		public readonly disableCache: boolean,
 		public readonly domFacade: DomFacade,
 		public readonly nodesFactory: INodesFactory,
 		public readonly documentWriter: IDocumentWriter,

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -60,8 +60,7 @@ function buildResultIterator(
 				allowUpdating: false,
 				allowXQuery: true,
 				debug: executionParameters.debug,
-				// TODO: should we inherit this from the outer evaluation somehow?
-				disableCache: false,
+				disableCache: executionParameters.disableCache,
 			},
 			(prefix) => staticContext.resolveNamespace(prefix),
 			// Set up temporary bindings for the given variables

--- a/src/parsing/convertXmlToAst.ts
+++ b/src/parsing/convertXmlToAst.ts
@@ -2,6 +2,7 @@ import { NODE_TYPES } from '../domFacade/ConcreteNode';
 import ExternalDomFacade from '../domFacade/ExternalDomFacade';
 import { stringToSequenceType } from '../expressions/dataTypes/Value';
 import { BUILT_IN_NAMESPACE_URIS } from '../expressions/staticallyKnownNamespaces';
+import { errXPTY0004 } from '../expressions/XPathErrors';
 import { Element } from '../types/Types';
 import { ASTAttributes, IAST } from './astHelper';
 
@@ -14,7 +15,7 @@ export default function convertXmlToAst(element: Element): IAST {
 		element.namespaceURI !== BUILT_IN_NAMESPACE_URIS.FONTOXPATH_NAMESPACE_URI &&
 		element.namespaceURI !== BUILT_IN_NAMESPACE_URIS.XQUERYX_UPDATING_NAMESPACE_URI
 	) {
-		throw new Error('AST should only contain XQUERYX elements');
+		throw errXPTY0004('The XML structure passed as an XQueryX program was not valid XQueryX');
 	}
 	const ast: IAST = [element.localName === 'stackTrace' ? 'x:stackTrace' : element.localName];
 


### PR DESCRIPTION
This removes a bit of duplicated code and instead makes `fontoxpath:evaluate` use `staticallyCompileXPath`. That enables caching for expressions evaluated this way and avoids unnecessary parsing.