### PR TITLE
Add matching specs for fn:format-integer

### DIFF
--- a/src/expressions/functions/builtInFunctions_numeric.ts
+++ b/src/expressions/functions/builtInFunctions_numeric.ts
@@ -48,10 +48,6 @@ const ROMAN_NUMBERS = [
 ];
 
 function convertIntegerToRoman(integer: string, isLowerCase?: boolean) {
-	if (integer === null) {
-		return '';
-	}
-
 	let int = parseInt(integer, 10);
 
 	const isNegative = int < 0;
@@ -82,10 +78,6 @@ function convertIntegerToRoman(integer: string, isLowerCase?: boolean) {
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 function convertIntegerToAlphabet(integer: string, isLowerCase?: boolean) {
-	if (integer === null) {
-		return '';
-	}
-
 	let int = parseInt(integer, 10);
 
 	const isNegative = int < 0;
@@ -137,21 +129,25 @@ const fnFormatInteger: FunctionDefinitionType = (
 	const sequenceValue = sequence.first();
 	const pictureValue = pictureSequence.first();
 
+	if (sequence.isEmpty()) {
+		return sequenceFactory.singleton(createAtomicValue('', ValueType.XSSTRING));
+	}
+
 	switch (pictureValue.value) {
 		case 'I': {
-			const romanString = convertIntegerToRoman(sequenceValue?.value ?? null);
+			const romanString = convertIntegerToRoman(sequenceValue.value);
 			return sequenceFactory.singleton(createAtomicValue(romanString, ValueType.XSSTRING));
 		}
 		case 'i': {
-			const romanString = convertIntegerToRoman(sequenceValue?.value ?? null, true);
+			const romanString = convertIntegerToRoman(sequenceValue.value, true);
 			return sequenceFactory.singleton(createAtomicValue(romanString, ValueType.XSSTRING));
 		}
 		case 'A': {
-			const alphabetString = convertIntegerToAlphabet(sequenceValue?.value ?? null);
+			const alphabetString = convertIntegerToAlphabet(sequenceValue.value);
 			return sequenceFactory.singleton(createAtomicValue(alphabetString, ValueType.XSSTRING));
 		}
 		case 'a': {
-			const alphabetString = convertIntegerToAlphabet(sequenceValue?.value ?? null, true);
+			const alphabetString = convertIntegerToAlphabet(sequenceValue.value, true);
 			return sequenceFactory.singleton(createAtomicValue(alphabetString, ValueType.XSSTRING));
 		}
 		default:

--- a/src/expressions/functions/builtInFunctions_numeric.ts
+++ b/src/expressions/functions/builtInFunctions_numeric.ts
@@ -48,7 +48,20 @@ const ROMAN_NUMBERS = [
 ];
 
 function convertIntegerToRoman(integer: string, isLowerCase?: boolean) {
+	if (integer === null) {
+		return '';
+	}
+
 	let int = parseInt(integer, 10);
+
+	const isNegative = int < 0;
+
+	int = Math.abs(int);
+
+	if (!int) {
+		return '-';
+	}
+
 	let romanString = ROMAN_NUMBERS.reduce((str, roman) => {
 		const q = Math.floor(int / roman.decimal);
 		int -= q * roman.decimal;
@@ -59,17 +72,30 @@ function convertIntegerToRoman(integer: string, isLowerCase?: boolean) {
 		romanString = romanString.toLowerCase();
 	}
 
+	if (isNegative) {
+		romanString = `-${romanString}`;
+	}
+
 	return romanString;
 }
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
 
 function convertIntegerToAlphabet(integer: string, isLowerCase?: boolean) {
+	if (integer === null) {
+		return '';
+	}
+
 	let int = parseInt(integer, 10);
+
+	const isNegative = int < 0;
+
+	int = Math.abs(int);
 
 	if (!int) {
 		return '-';
 	}
+
 	let output = '';
 	let digit;
 
@@ -81,6 +107,10 @@ function convertIntegerToAlphabet(integer: string, isLowerCase?: boolean) {
 
 	if (isLowerCase) {
 		output = output.toLowerCase();
+	}
+
+	if (isNegative) {
+		output = `-${output}`;
 	}
 
 	return output;
@@ -106,21 +136,22 @@ const fnFormatInteger: FunctionDefinitionType = (
 ) => {
 	const sequenceValue = sequence.first();
 	const pictureValue = pictureSequence.first();
+
 	switch (pictureValue.value) {
 		case 'I': {
-			const romanString = convertIntegerToRoman(sequenceValue.value);
+			const romanString = convertIntegerToRoman(sequenceValue?.value ?? null);
 			return sequenceFactory.singleton(createAtomicValue(romanString, ValueType.XSSTRING));
 		}
 		case 'i': {
-			const romanString = convertIntegerToRoman(sequenceValue.value, true);
+			const romanString = convertIntegerToRoman(sequenceValue?.value ?? null, true);
 			return sequenceFactory.singleton(createAtomicValue(romanString, ValueType.XSSTRING));
 		}
 		case 'A': {
-			const alphabetString = convertIntegerToAlphabet(sequenceValue.value);
+			const alphabetString = convertIntegerToAlphabet(sequenceValue?.value ?? null);
 			return sequenceFactory.singleton(createAtomicValue(alphabetString, ValueType.XSSTRING));
 		}
 		case 'a': {
-			const alphabetString = convertIntegerToAlphabet(sequenceValue.value, true);
+			const alphabetString = convertIntegerToAlphabet(sequenceValue?.value ?? null, true);
 			return sequenceFactory.singleton(createAtomicValue(alphabetString, ValueType.XSSTRING));
 		}
 		default:

--- a/test/assets/unrunnableTestCases.csv
+++ b/test/assets/unrunnableTestCases.csv
@@ -513,7 +513,6 @@ format-integer-032-it,Error: XPST0017: Function Q{http://www.w3.org/2005/xpath-f
 format-integer-033,Error: Picture: 1;o(-en) is not implemented yet. The supported picture strings are "A", "a", "I", and "i"
 format-integer-034,AssertionError: expected [Function] to throw error matching /FODF1310/ but got 'Picture: 1;o(-er)z is not implemented…'
 format-integer-035,Error: Picture: Ww;t is not implemented yet. The supported picture strings are "A", "a", "I", and "i"
-format-integer-036,Error: Picture: Ww is not implemented yet. The supported picture strings are "A", "a", "I", and "i"
 format-integer-037,AssertionError: expected [Function] to throw error matching /FODF1310/ but got 'Picture: Ww;o()( is not implemented y…'
 format-integer-038,Error: Picture: ()Ww;o is not implemented yet. The supported picture strings are "A", "a", "I", and "i"
 format-integer-039,Error: Picture:   is not implemented yet. The supported picture strings are "A", "a", "I", and "i"

--- a/test/specs/parsing/functions/functions.numeric.tests.ts
+++ b/test/specs/parsing/functions/functions.numeric.tests.ts
@@ -224,6 +224,10 @@ describe('numeric functions', () => {
 			chai.assert.equal(evaluateXPathToString('format-integer(57, "i")'), 'lvii');
 		});
 
+		it('returns -lvii for -57', () => {
+			chai.assert.equal(evaluateXPathToString('format-integer(-57, "i")'), '-lvii');
+		});
+
 		it('returns G for 7', () => {
 			chai.assert.equal(evaluateXPathToString('format-integer(7, "A")'), 'G');
 		});
@@ -232,12 +236,34 @@ describe('numeric functions', () => {
 			chai.assert.equal(evaluateXPathToString('format-integer(7, "a")'), 'g');
 		});
 
+		it('returns -g for -7', () => {
+			chai.assert.equal(evaluateXPathToString('format-integer(-7, "a")'), '-g');
+		});
+
 		it('returns AB for 28', () => {
 			chai.assert.equal(evaluateXPathToString('format-integer(28, "A")'), 'AB');
 		});
 
 		it('returns ab for 28', () => {
 			chai.assert.equal(evaluateXPathToString('format-integer(28, "a")'), 'ab');
+		});
+
+		it('returns -ab for -28', () => {
+			chai.assert.equal(evaluateXPathToString('format-integer(-28, "a")'), '-ab');
+		});
+
+		it('returns - for 0', () => {
+			chai.assert.equal(evaluateXPathToString('format-integer(0, "a")'), '-');
+			chai.assert.equal(evaluateXPathToString('format-integer(0, "A")'), '-');
+			chai.assert.equal(evaluateXPathToString('format-integer(0, "i")'), '-');
+			chai.assert.equal(evaluateXPathToString('format-integer(0, "I")'), '-');
+		});
+
+		it('returns "" for ()', () => {
+			chai.assert.equal(evaluateXPathToString('format-integer((), "a")'), '');
+			chai.assert.equal(evaluateXPathToString('format-integer((), "A")'), '');
+			chai.assert.equal(evaluateXPathToString('format-integer((), "i")'), '');
+			chai.assert.equal(evaluateXPathToString('format-integer((), "I")'), '');
 		});
 
 		it('throws for unknown pictures', () => {


### PR DESCRIPTION
Handled according to specs:
- If $value is an empty sequence, the function returns an empty string.
- If the value of $value is negative, the functions returns  the absolute value of $value, and a minus sign is prepended to the result

The spec doesn’t prescribe anything for 0, however the function will always return "-"
