### PR TITLE
Remove recursions from array:flatten function

### DIFF
--- a/test/specs/parsing/arrays/arrayFunctions.tests.ts
+++ b/test/specs/parsing/arrays/arrayFunctions.tests.ts
@@ -437,17 +437,17 @@ describe('functions over arrays', () => {
 
 		it('can flatten long arrays', () =>
 			chai.assert.equal(
-				evaluateXPathToNumber('array:flatten(array{1 to 200000}) => count()', documentNode),
-				200000
+				evaluateXPathToNumber('array:flatten(array{1 to 20000}) => count()', documentNode),
+				20000
 			));
 
 		it('can flatten deep arrays', () =>
 			chai.assert.equal(
 				evaluateXPathToNumber(
-					'(1 to 2000) => fold-left([1], function ($accum, $item) {[$accum, $item]}) => count()',
+					'(1 to 200) => fold-left([1], function ($accum, $item) {[$accum, $item]}) => array:flatten() => count()',
 					documentNode
 				),
-				1
+				201
 			));
 	});
 

--- a/test/specs/parsing/arrays/arrayFunctions.tests.ts
+++ b/test/specs/parsing/arrays/arrayFunctions.tests.ts
@@ -3,6 +3,7 @@ import {
 	evaluateXPath,
 	evaluateXPathToArray,
 	evaluateXPathToBoolean,
+	evaluateXPathToNumber,
 	evaluateXPathToNumbers,
 	evaluateXPathToString,
 	evaluateXPathToStrings,
@@ -432,6 +433,21 @@ describe('functions over arrays', () => {
 			chai.assert.deepEqual(
 				evaluateXPathToStrings('array:flatten(["a", ["b", "c"], "d"])', documentNode),
 				['a', 'b', 'c', 'd']
+			));
+
+		it('can flatten long arrays', () =>
+			chai.assert.equal(
+				evaluateXPathToNumber('array:flatten(array{1 to 200000}) => count()', documentNode),
+				200000
+			));
+
+		it('can flatten deep arrays', () =>
+			chai.assert.equal(
+				evaluateXPathToNumber(
+					'(1 to 2000) => fold-left([1], function ($accum, $item) {[$accum, $item]}) => count()',
+					documentNode
+				),
+				1
 			));
 	});
 


### PR DESCRIPTION
This makes it work for long and deep arrays as well

Fixes #536 