### PR TITLE
Codegen fixes

### DIFF
--- a/src/jsCodegen/compileAstToJavaScript.ts
+++ b/src/jsCodegen/compileAstToJavaScript.ts
@@ -40,7 +40,7 @@ function wrapCompiledCode(code: string, shouldUseContextItem: boolean): string {
 	let finalCode = `
 	return (contextItem, domFacade, runtimeLib, options) => {
 		const {
-			XPDY0002,
+			errXPDY0002,
 		} = runtimeLib;`;
 
 	if (shouldUseContextItem) {

--- a/src/jsCodegen/emitLogicalExpr.ts
+++ b/src/jsCodegen/emitLogicalExpr.ts
@@ -61,7 +61,7 @@ function emitLogicalExpr(
 	const [secondExpr, secondBucket] = emitOperand(ast, 'secondOperand', contextItemExpr, context);
 	const logicalOpExpr = mapPartialCompilationResult(firstAsBool, (firstAsBool) => {
 		const secondType = astHelper.getAttribute(
-			astHelper.followPath(ast, ['firstOperand', '*']),
+			astHelper.followPath(ast, ['secondOperand', '*']),
 			'type'
 		);
 		const secondAsBool = emitEffectiveBooleanValue(

--- a/test/specs/parsing/jsCodegen/pathExpr.tests.ts
+++ b/test/specs/parsing/jsCodegen/pathExpr.tests.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai';
 import * as slimdom from 'slimdom';
 import jsonMlMapper from 'test-helpers/jsonMlMapper';
 
-import { ReturnType } from 'fontoxpath';
+import { evaluateXPath, Language, parseScript, ReturnType } from 'fontoxpath';
 import evaluateXPathWithJsCodegen from './evaluateXPathWithJsCodegen';
 
 describe('paths (js-codegen)', () => {
@@ -27,6 +27,104 @@ describe('paths (js-codegen)', () => {
 		);
 		chai.assert.isFalse(
 			evaluateXPathWithJsCodegen('/does-not-exist', titleNode, null, ReturnType.BOOLEAN)
+		);
+	});
+
+	it('handles paths with filterExpr', () => {
+		const titleNode = documentNode.firstChild.firstChild;
+		chai.assert.isFalse(
+			evaluateXPathWithJsCodegen('self::title/false()', titleNode, null, ReturnType.BOOLEAN)
+		);
+		// context item is also a filterExpr
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen('self::title/./.', titleNode, null, ReturnType.FIRST_NODE),
+			titleNode
+		);
+		// filterExpr with following steps must result in a node
+		chai.assert.throws(
+			() =>
+				evaluateXPathWithJsCodegen(
+					'false()/self::title',
+					titleNode,
+					null,
+					ReturnType.BOOLEAN
+				),
+			/XPTY0019/
+		);
+	});
+
+	it('handles paths with filterExpr with nested paths (single value)', () => {
+		// Fonto's xq interpolates expressions using AST manipulation, which may result in
+		// having a pathExpr inside of a filterExpr:
+		const outerAst = parseScript(
+			'$a/*',
+			{ language: Language.XQUERY_3_1_LANGUAGE, debug: false },
+			new slimdom.Document()
+		);
+		const innerAst = parseScript(
+			'self::nope',
+			{ language: Language.XQUERY_3_1_LANGUAGE, debug: false },
+			new slimdom.Document()
+		);
+		const actualExpression = evaluateXPath<slimdom.Element, ReturnType.FIRST_NODE>(
+			'descendant::Q{http://www.w3.org/2005/XQueryX}queryBody/*',
+			innerAst,
+			null,
+			{},
+			ReturnType.FIRST_NODE
+		);
+		const expressionToReplace = evaluateXPath<slimdom.Element, ReturnType.FIRST_NODE>(
+			`descendant::Q{http://www.w3.org/2005/XQueryX}varRef`,
+			outerAst,
+			null,
+			{},
+			ReturnType.FIRST_NODE
+		);
+		expressionToReplace.replaceWith(actualExpression);
+
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(
+				outerAst,
+				documentNode.documentElement,
+				null,
+				ReturnType.FIRST_NODE
+			),
+			null
+		);
+	});
+
+	it('handles paths with filterExpr with nested paths (multiple values)', () => {
+		// Fonto's xq interpolates expressions using AST manipulation, which may result in
+		// having a pathExpr inside of a filterExpr:
+		const outerAst = parseScript(
+			'$a/*',
+			{ language: Language.XQUERY_3_1_LANGUAGE, debug: false },
+			new slimdom.Document()
+		);
+		const innerAst = parseScript(
+			'*',
+			{ language: Language.XQUERY_3_1_LANGUAGE, debug: false },
+			new slimdom.Document()
+		);
+		const actualExpression = evaluateXPath<slimdom.Element, ReturnType.FIRST_NODE>(
+			'descendant::Q{http://www.w3.org/2005/XQueryX}queryBody/*',
+			innerAst,
+			null,
+			{},
+			ReturnType.FIRST_NODE
+		);
+		const expressionToReplace = evaluateXPath<slimdom.Element, ReturnType.FIRST_NODE>(
+			`descendant::Q{http://www.w3.org/2005/XQueryX}varRef`,
+			outerAst,
+			null,
+			{},
+			ReturnType.FIRST_NODE
+		);
+		expressionToReplace.replaceWith(actualExpression);
+
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(outerAst, documentNode, null, ReturnType.FIRST_NODE),
+			documentNode.documentElement.firstElementChild
 		);
 	});
 });

--- a/test/specs/parsing/jsCodegen/returnValues.tests.ts
+++ b/test/specs/parsing/jsCodegen/returnValues.tests.ts
@@ -44,6 +44,14 @@ describe('return values', () => {
 				ReturnType.BOOLEAN
 			)
 		);
+		chai.assert.isTrue(
+			evaluateXPathWithJsCodegen(
+				`false() or self::xml`,
+				documentNode.documentElement,
+				null,
+				ReturnType.BOOLEAN
+			)
+		);
 	});
 
 	it('evaluates to nodes', () => {


### PR DESCRIPTION
This fixes a few issues in codegen:

* fix "import" of errXPDY0002 helper (missed a rename)
* fix missing null check before next steps after a filterExpr
* properly handle filterExpr that results in a generator - this doesn't normally happen in supported expressions parsed from strings I think, but Fonto's XPath interpolation can currently result in an AST that has pathExpr nested in filterExpr...
* fix type check for the second operand in logical expressions - it used the first type for both operands, so would omit the `!!` if that operand was boolean, meaning `false() or self::*` would return a node