### PR TITLE
Codegen optimizations

### DIFF
--- a/src/jsCodegen/CodeGenContext.ts
+++ b/src/jsCodegen/CodeGenContext.ts
@@ -32,7 +32,7 @@ export class CodeGenContext {
 
 	public getIdentifierFor(
 		expr: PartialCompilationResult,
-		prefix = 'v'
+		prefix: string
 	): PartialCompilationResult {
 		return mapPartialCompilationResult(expr, (expr) => {
 			let identifierExpr = this._identifierExprByExpr.get(expr);
@@ -49,7 +49,7 @@ export class CodeGenContext {
 		});
 	}
 
-	public getNewIdentifier(prefix = 'v'): PartiallyCompiledAstAccepted {
+	public getNewIdentifier(prefix: string): PartiallyCompiledAstAccepted {
 		return this.getVarInScope(this._getNewIdentifier(prefix));
 	}
 

--- a/src/jsCodegen/emitFunctionCallExpr.ts
+++ b/src/jsCodegen/emitFunctionCallExpr.ts
@@ -137,26 +137,22 @@ function emitFunctionArgumentsConversion(
 
 function emitFunctionReturnTypeConversion(
 	callFunctionExpr: PartialCompilationResult,
-	returnType: SequenceType,
-	context: CodeGenContext
+	returnType: SequenceType
 ) {
-	return mapPartialCompilationResult(
-		context.getIdentifierFor(callFunctionExpr),
-		(callFunctionExpr) => {
-			// We support (zero or) one string, node or boolean
-			if (
-				!doesTypeAllowMultiple(returnType) &&
-				([ValueType.XSBOOLEAN, ValueType.XSSTRING].includes(returnType.type) ||
-					isSubtypeOf(returnType.type, ValueType.NODE))
-			) {
-				// Singleton string or empty sequence, handled by runtimeLib
-				return callFunctionExpr;
-			}
-			return rejectAst(
-				`Function return type ${valueTypeToString(returnType.type)} not supported`
-			);
+	return mapPartialCompilationResult(callFunctionExpr, (callFunctionExpr) => {
+		// We support (zero or) one string, node or boolean
+		if (
+			!doesTypeAllowMultiple(returnType) &&
+			([ValueType.XSBOOLEAN, ValueType.XSSTRING].includes(returnType.type) ||
+				isSubtypeOf(returnType.type, ValueType.NODE))
+		) {
+			// Singleton string or empty sequence, handled by runtimeLib
+			return callFunctionExpr;
 		}
-	);
+		return rejectAst(
+			`Function return type ${valueTypeToString(returnType.type)} not supported`
+		);
+	});
 }
 
 export function emitFunctionCallExpr(
@@ -219,7 +215,7 @@ export function emitFunctionCallExpr(
 			argsExpr.variables
 		)
 	);
-	return emitFunctionReturnTypeConversion(callFunction, functionProperties.returnType, context);
+	return emitFunctionReturnTypeConversion(callFunction, functionProperties.returnType);
 }
 
 function emitContextItemCheck(

--- a/src/jsCodegen/emitFunctionCallExpr.ts
+++ b/src/jsCodegen/emitFunctionCallExpr.ts
@@ -34,11 +34,13 @@ const supportedFunctions: Record<
 		context: CodeGenContext
 	) => PartialCompilationResult
 > = {
+	'false#0': emitFalseFunction,
 	'local-name#0': emitLocalNameFunction,
 	'local-name#1': emitLocalNameFunction,
 	'name#0': emitNameFunction,
 	'name#1': emitNameFunction,
 	'not#1': emitNotFunction,
+	'true#0': emitTrueFunction,
 };
 
 // Built-in function allow list
@@ -47,7 +49,7 @@ const supportedFunctions: Record<
 // are supported.
 const supportedBuiltinFunctions: Record<string, string[]> = {
 	[BUILT_IN_NAMESPACE_URIS.FONTOXPATH_NAMESPACE_URI]: ['version#0'],
-	['']: ['true#0', 'false#0', 'root#1', 'path#1'],
+	['']: ['root#1', 'path#1'],
 };
 
 function emitFunctionArgumentConversion(
@@ -308,4 +310,20 @@ function emitNotFunction(
 	return mapPartialCompilationResult(argAsBool, (argAsBool) =>
 		acceptAst(`!${argAsBool.code}`, { type: GeneratedCodeBaseType.Value }, argAsBool.variables)
 	);
+}
+
+function emitFalseFunction(
+	_ast: IAST,
+	_contextItemExpr: PartialCompilationResult,
+	_context: CodeGenContext
+): PartialCompilationResult {
+	return acceptAst('false', { type: GeneratedCodeBaseType.Value }, []);
+}
+
+function emitTrueFunction(
+	_ast: IAST,
+	_contextItemExpr: PartialCompilationResult,
+	_context: CodeGenContext
+): PartialCompilationResult {
+	return acceptAst('true', { type: GeneratedCodeBaseType.Value }, []);
 }

--- a/test/specs/parsing/jsCodegen/functionCall.tests.ts
+++ b/test/specs/parsing/jsCodegen/functionCall.tests.ts
@@ -16,6 +16,12 @@ describe('function calls', () => {
 			'node()?',
 			({ domFacade }, str, bool, node) => (bool ? domFacade.getFirstChild(node) : null)
 		);
+		registerCustomXPathFunction(
+			{ localName: 'functionCallWithItem', namespaceURI: 'test' },
+			['item()?'],
+			'xs:boolean',
+			(_dynamicContext, item) => !!item
+		);
 	});
 
 	beforeEach(() => {
@@ -73,6 +79,45 @@ describe('function calls', () => {
 				ReturnType.FIRST_NODE
 			),
 			null
+		);
+	});
+
+	it('can call functions with item() arguments, which accept all supported types', () => {
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(
+				'Q{test}functionCallWithItem(true())',
+				null,
+				null,
+				ReturnType.BOOLEAN
+			),
+			true
+		);
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(
+				'Q{test}functionCallWithItem("a")',
+				null,
+				null,
+				ReturnType.BOOLEAN
+			),
+			true
+		);
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(
+				'Q{test}functionCallWithItem(/xml)',
+				documentNode,
+				null,
+				ReturnType.BOOLEAN
+			),
+			true
+		);
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen(
+				'Q{test}functionCallWithItem(/nope)',
+				documentNode,
+				null,
+				ReturnType.BOOLEAN
+			),
+			false
 		);
 	});
 


### PR DESCRIPTION
This adds a few more perf optimizations for codegen:

* Make function calls lazy - fixes a potential performance regression compared to non-codegen evaluation where functions might be called even if the result is not needed (e.g., in `false() and my:func()`).
* Inline true and false constants instead of using runTimeLib to call `fn:true()` and `fn:false()`