### PR TITLE
Fix a rare bug where a variable declaration in a module breaks

### DIFF
--- a/src/parsing/processProlog.ts
+++ b/src/parsing/processProlog.ts
@@ -21,6 +21,7 @@ import {
 	errXPST0081,
 	errXQST0045,
 	errXQST0047,
+    errXQST0049,
 	errXQST0060,
 	errXQST0066,
 	errXQST0070,
@@ -137,9 +138,7 @@ function processFunctionDefinition(
 				paramTypes.length
 			)
 		) {
-			throw new Error(
-				`XQST0049: The function Q{${declarationNamespaceURI}}${declarationLocalName}#${paramTypes.length} has already been declared.`
-			);
+			throw errXQST0049(declarationNamespaceURI, declarationLocalName);
 		}
 
 		if (!createExpressions) {
@@ -518,7 +517,7 @@ export default function processProlog(
 			);
 			staticallyCompilableExpressions.push({
 				expression: compiledVariableAsExpression,
-				staticContextLeaf: staticContext,
+				staticContextLeaf: new StaticContext(staticContext),
 			});
 
 			registeredVariables.push({

--- a/src/parsing/processProlog.ts
+++ b/src/parsing/processProlog.ts
@@ -21,7 +21,7 @@ import {
 	errXPST0081,
 	errXQST0045,
 	errXQST0047,
-    errXQST0049,
+	errXQST0049,
 	errXQST0060,
 	errXQST0066,
 	errXQST0070,

--- a/test/specs/parsing/mainModules.tests.ts
+++ b/test/specs/parsing/mainModules.tests.ts
@@ -126,18 +126,31 @@ declare function fn () external; 1`,
 
 	it('Can do circular imports', () => {
 		registerXQueryModule(`
+module namespace test = "http://www.example.org/mainmodules.shared#3";
+
+declare %public function test:hello(){"Hello"};
+`);
+
+		registerXQueryModule(`
 module namespace test = "http://www.example.org/mainmodules.tests#3";
+import module namespace shared="http://www.example.org/mainmodules.shared#3";
+
+declare variable $test:space := " ";
 
 declare %public function test:AAA($a as xs:integer) as xs:string {
-   if ($a < 0) then "" else "Hello " || test:BBB($a - 1)
+   if ($a < 0) then "" else shared:hello() || $test:space || test:BBB($a - 1)
 };
 `);
 
 		registerXQueryModule(`
 module namespace test = "http://www.example.org/mainmodules.tests#3";
 
+import module namespace shared="http://www.example.org/mainmodules.shared#3";
+
+declare variable $test:world := "World";
+
 declare %public function test:BBB($a as xs:integer) as xs:string  {
-   if ($a < 0) then "" else test:AAA($a - 1) || " World"
+   if ($a < 0) then "" else test:AAA($a - 1) || $test:space || $test:world
 };
 `);
 

--- a/test/specs/parsing/registerXQueryModule.tests.ts
+++ b/test/specs/parsing/registerXQueryModule.tests.ts
@@ -235,7 +235,7 @@ declare function x:fn () external;`);
 				};`
 			)
 		).to.throw(
-			'XQST0049: The function Q{http://www.example.com}duplicate-fn#0 has already been declared.'
+			'XQST0049: The function or variable "Q{http://www.example.com}duplicate-fn" is declared more than once.'
 		);
 	});
 


### PR DESCRIPTION
It caused module imports to be played off directly on the 'root' static context, which can cause duplicate function registration

TODO: unit test