### PR TITLE
Fix text() not selecting CDATA sections

### DIFF
--- a/src/getBuckets.ts
+++ b/src/getBuckets.ts
@@ -42,7 +42,11 @@ export function getBucketsForPointer(pointer: NodePointer, domFacade: DomFacade)
  * @param node - The node which buckets should be retrieved
  */
 export function getBucketsForNode(node: Node): Bucket[] {
-	const nodeType = node.nodeType;
+	let nodeType = node.nodeType;
+	// Put CDataSection nodes in the Text bucket
+	if (nodeType === NODE_TYPES.CDATA_SECTION_NODE) {
+		nodeType = NODE_TYPES.TEXT_NODE;
+	}
 	let localName;
 
 	if (nodeType === NODE_TYPES.ATTRIBUTE_NODE || nodeType === NODE_TYPES.ELEMENT_NODE) {

--- a/src/jsCodegen/emitTest.ts
+++ b/src/jsCodegen/emitTest.ts
@@ -36,7 +36,8 @@ function emitTextTest(
 	return [
 		mapPartialCompilationResult(contextItemExpr, (contextItemExpr) =>
 			acceptAst(
-				`${contextItemExpr.code}.nodeType === /*TEXT_NODE*/ ${NODE_TYPES.TEXT_NODE}`,
+				`(${contextItemExpr.code}.nodeType === /*TEXT_NODE*/ ${NODE_TYPES.TEXT_NODE} ||
+				${contextItemExpr.code}.nodeType === /* CDATA_SECTION_NODE */ ${NODE_TYPES.CDATA_SECTION_NODE})`,
 				{
 					type: GeneratedCodeBaseType.Value,
 				},

--- a/test/specs/parsing/getBucketsForNode.tests.ts
+++ b/test/specs/parsing/getBucketsForNode.tests.ts
@@ -12,5 +12,8 @@ describe('getBucketsForNode', () => {
 	});
 	it('returns the correct buckets for text nodes', () => {
 		chai.assert.deepEqual(getBucketsForNode(doc.createTextNode('A piece of text')), ['type-3']);
+		chai.assert.deepEqual(getBucketsForNode(doc.createCDATASection('A piece of cdata')), [
+			'type-3',
+		]);
 	});
 });

--- a/test/specs/parsing/jsCodegen/nodeTests.tests.ts
+++ b/test/specs/parsing/jsCodegen/nodeTests.tests.ts
@@ -26,6 +26,13 @@ describe('node tests', () => {
 		chai.assert.isTrue(
 			evaluateXPathWithJsCodegen('/xml/text()', documentNode, null, ReturnType.BOOLEAN)
 		);
+		// text() should also match CDATA sections
+		const cdata = documentNode.createCDATASection('hello');
+		documentNode.documentElement.replaceChildren(cdata);
+		chai.assert.equal(
+			evaluateXPathWithJsCodegen('/xml/text()', documentNode, null, ReturnType.FIRST_NODE),
+			cdata
+		);
 	});
 
 	it('does not select non-text nodes', () => {


### PR DESCRIPTION
While the expression version of the text() node test did check for the CDataSection node type, the codegen-emitted code did not. Additionally, the bucket generated for a CDataSection node was type-4, while the text() selector always uses type-3. This fixes both issues and adds a few tests to confirm that fix.