### PR TITLE
Fixes tscc error caused by outdated dependency version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4773,9 +4773,9 @@
 			]
 		},
 		"node_modules/google-closure-compiler-osx": {
-			"version": "20221004.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20221004.0.0.tgz",
-			"integrity": "sha512-z5V7BvaMauPga8DMTt9u6RGcjBdLAuv4gL2Ebw5NIQRTAHVkEVzCd3kiMX7CVCGhmWdS/1r3jZcCg4BswGia6w==",
+			"version": "20230206.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20230206.0.0.tgz",
+			"integrity": "sha512-lJ/Y4HTk+KdL6PhLmmalP/3DdzGK0mS0+htuFP6y4t9+QXiUKnpHWx/VDQ3Fwm2fWEzqDxfhX3R+wC9lBvFiAg==",
 			"cpu": [
 				"x32",
 				"x64",
@@ -10645,7 +10645,7 @@
 				"fs-extra": "^10.0.1",
 				"google-closure-compiler-java": "^20221004.0.0",
 				"google-closure-compiler-linux": "^20221004.0.0",
-				"google-closure-compiler-osx": "^20221004.0.0",
+				"google-closure-compiler-osx": "^20230206.0.0",
 				"google-closure-compiler-windows": "^20221004.0.0",
 				"ora": "^5.4.1",
 				"resolve-from": "^5.0.0",
@@ -13330,9 +13330,9 @@
 			"optional": true
 		},
 		"google-closure-compiler-osx": {
-			"version": "20221004.0.0",
-			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20221004.0.0.tgz",
-			"integrity": "sha512-z5V7BvaMauPga8DMTt9u6RGcjBdLAuv4gL2Ebw5NIQRTAHVkEVzCd3kiMX7CVCGhmWdS/1r3jZcCg4BswGia6w==",
+			"version": "20230206.0.0",
+			"resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20230206.0.0.tgz",
+			"integrity": "sha512-lJ/Y4HTk+KdL6PhLmmalP/3DdzGK0mS0+htuFP6y4t9+QXiUKnpHWx/VDQ3Fwm2fWEzqDxfhX3R+wC9lBvFiAg==",
 			"dev": true,
 			"optional": true
 		},

--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
 	"dependencies": {
 		"prsc": "4.0.0",
 		"xspattern": "^3.1.0"
+	},
+	"overrides": {
+		"google-closure-compiler-osx": "^20230206.0.0"
 	}
 }


### PR DESCRIPTION
On OSX Ventura with an Intel processor, the `tscc` compiler fails due to one of its dependency versions being out-of-date. `tscc` is not actively maintained, so as a workaround I added an NPM dependency version override to the `package.json` of `fontoxpath`.

Relevant `tscc` issue here: https://github.com/theseanl/tscc/issues/812