### PR TITLE
Statically compile type test for instance of operator

### DIFF
--- a/src/expressions/operators/types/InstanceOfOperator.ts
+++ b/src/expressions/operators/types/InstanceOfOperator.ts
@@ -18,7 +18,7 @@ class InstanceOfOperator extends Expression {
 	) {
 		super(
 			expression.specificity,
-			[expression],
+			[expression, typeTest],
 			{ canBeStaticallyEvaluated: false },
 			false,
 			type,

--- a/test/specs/parsing/operators/types/InstanceOfOperator.tests.ts
+++ b/test/specs/parsing/operators/types/InstanceOfOperator.tests.ts
@@ -1,8 +1,7 @@
 import * as chai from 'chai';
-import * as slimdom from 'slimdom';
+import { Document } from 'slimdom';
 
-import { evaluateXPathToBoolean } from 'fontoxpath';
-import evaluateXPathToAsyncSingleton from 'test-helpers/evaluateXPathToAsyncSingleton';
+import { Language, evaluateXPathToBoolean } from 'fontoxpath';
 
 describe('instance of operator', () => {
 	it('returns true for a valid instance of xs:boolean', () =>
@@ -38,4 +37,17 @@ describe('instance of operator', () => {
 
 	it('returns false for an invalid instance of node()', () =>
 		chai.assert.isFalse(evaluateXPathToBoolean('1 instance of node()')));
+
+	it('keeps namespaces into account', () => {
+		chai.assert.isTrue(
+			evaluateXPathToBoolean(
+				`declare namespace x='x';
+<x:ele/> instance of element(x:ele)`,
+				new Document(),
+				null,
+				null,
+				{ language: Language.XQUERY_3_1_LANGUAGE },
+			),
+		);
+	});
 });


### PR DESCRIPTION
Without that, the namespace part is never picked up

Fixes #679 