### PR TITLE
Allow attributes to be passed as arguments to custom functions

### DIFF
--- a/src/registerCustomXPathFunction.ts
+++ b/src/registerCustomXPathFunction.ts
@@ -82,9 +82,6 @@ export function adaptXPathValueToJavascriptValue(
 		sequenceType.mult === SequenceMultiplicity.ONE_OR_MORE
 	) {
 		return valueSequence.getAllValues().map((value) => {
-			if (isSubtypeOf(value.type, ValueType.ATTRIBUTE)) {
-				throw new Error('Cannot pass attribute nodes to custom functions');
-			}
 			return transformXPathItemToJavascriptObject(value, executionParameters).next(
 				IterationHint.NONE,
 			).value;

--- a/test/specs/parsing/registerCustomXPathFunction.tests.ts
+++ b/test/specs/parsing/registerCustomXPathFunction.tests.ts
@@ -280,13 +280,12 @@ describe('registerCustomXPathFunction', () => {
 		);
 	});
 
-	it('disallows attributes as parameters', () => {
-		chai.assert.throws(
-			() =>
-				evaluateXPathToString('test:custom-function3(//@*)', documentNode, null, null, {
-					namespaceResolver: identityNamespaceResolver,
-				}),
-			'Cannot pass attribute nodes',
+	it('allows attributes as parameters', () => {
+		chai.assert.equal(
+			evaluateXPathToString('test:custom-function3(//@*)', documentNode, null, null, {
+				namespaceResolver: identityNamespaceResolver,
+			}),
+			'someValue',
 		);
 	});
 


### PR DESCRIPTION
I'm not sure why this error checking was there: from what I can tell it works fine to pass an attribute into a custom function and the code that is called to transform the xpath value into a javascript value seems to handle attributes: https://github.com/egh/fontoxpath/blob/allow-attribute-args-for-functions/src/transformXPathItemToJavascriptObject.ts#L140

